### PR TITLE
51 generate api xml settings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,7 @@
 			core-$(CoreVersion)
 		</PackageTags>
 
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	<ItemGroup>
 	  <None Include="..\README.md">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+	<PropertyGroup>
+		<GenerateDocumentationFile Condition="'$(IsPackable)' == 'false'">false</GenerateDocumentationFile>
+		<NoWarn Condition="'$(IsPackable)' == 'false'">$(NoWarn);CS1591</NoWarn>
+	</PropertyGroup>
+</Project>

--- a/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
+++ b/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
@@ -10,9 +10,16 @@ using System.Threading;
 
 namespace InteractionFlow.Analyzers
 {
+    /// <summary>
+    /// The Analyzer for InteractionFlow.
+    /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
+
     public class InteractionFlowAnalyzersAnalyzer : DiagnosticAnalyzer
     {
+        /// <summary>
+        /// The diagnostic identifier for invalid Interaction Flow architecture layer dependencies.
+        /// </summary>
         public const string DiagnosticId = "InteractionFlowArchitecture001";
 
         private static readonly LocalizableString Title =
@@ -45,9 +52,11 @@ namespace InteractionFlow.Analyzers
             return RulesBySeverity.TryGetValue(severity, out var rule) ? rule : Rule;
         }
 
+        /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
                => ImmutableArray.Create(Rule);
 
+        /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);

--- a/InteractionFlow.Samples.Notepad.Core/InteractionFlow.Samples.Notepad.Core.csproj
+++ b/InteractionFlow.Samples.Notepad.Core/InteractionFlow.Samples.Notepad.Core.csproj
@@ -1,1 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">	<PropertyGroup>		<TargetFramework>netstandard2.1</TargetFramework>	</PropertyGroup>	<ItemGroup>		<ProjectReference Include="..\InteractionFlow.Core\InteractionFlow.Core.csproj" />		<ProjectReference Include="..\InteractionFlow.Standard\InteractionFlow.Standard.csproj" />		<ProjectReference Include="..\InteractionFlow.Analyzers\InteractionFlow.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />	</ItemGroup></Project>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\InteractionFlow.Core\InteractionFlow.Core.csproj" />
+		<ProjectReference Include="..\InteractionFlow.Standard\InteractionFlow.Standard.csproj" />
+		<ProjectReference Include="..\InteractionFlow.Analyzers\InteractionFlow.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+</Project>


### PR DESCRIPTION
#51 ビルド設定でAPIのXMLを自動生成する
- Update Directory.Build.props
  基本設定の追加
- Update InteractionFlow.Samples.Notepad.Core.csproj 
  Sample なのに `<IsPackable>false</IsPackable>` じゃなかった
- Create Directory.Build.targets
  IsPackable の時にXMLドキュメントを強制しないため
- Update InteractionFlowAnalyzersAnalyzer.cs
  公開Packageなため、簡単なDocumentを追加