### PR TITLE
#65 ビルドワークフローの過剰発火を避ける

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -4,6 +4,15 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "**/*.cs"
+      - "**/*.csproj"
+      - "**/*.props"
+      - "**/*.targets"
+      - "InteractionFlow.slnx"
+      - "global.json"
+      - ".editorconfig"
+      - "NUGET_README.md"
   push:
     tags:
       - "packages-*"


### PR DESCRIPTION
- CI対象パスを指定