### PR TITLE
71 dev core050   4 analyzer による依存ツリーチェック

### DIFF
--- a/InteractionFlow.Analyzers.Tests/README.md
+++ b/InteractionFlow.Analyzers.Tests/README.md
@@ -1,0 +1,134 @@
+# InteractionFlow.Analyzers.Tests
+
+`InteractionFlow.Analyzers` の Roslyn Analyzer テストプロジェクトです。
+`Microsoft.CodeAnalysis.CSharp.Testing` と xUnit を使い、インメモリの C# ソースと `.editorconfig` を渡して診断結果を検証します。
+
+## テスト対象
+
+現在のテストは `InteractionFlowAnalyzersAnalyzer` の 2 つの診断を対象にしています。
+
+| ID | 内容 |
+| --- | --- |
+| `InteractionFlowArchitecture001` | レイヤー依存関係規則 |
+| `InteractionFlowArchitecture002` | `IDependencyNode` 宣言規則 |
+
+## テスト基盤
+
+主なテストコードは `UnitTest1.cs` にあります。
+
+- `VerifyAsync`
+  - `CSharpAnalyzerTest<InteractionFlowAnalyzersAnalyzer, DefaultVerifier>` を組み立てます。
+  - テストごとにインメモリ `.editorconfig` を追加します。
+  - `interactionflow_enabled`、`interactionflow_mode`、`interactionflow_allowed_roots` を指定できます。
+- `ExpectedHidden`
+  - `InteractionFlowArchitecture001` の Hidden 診断期待値を作ります。
+- `ExpectedDependencyHidden`
+  - `InteractionFlowArchitecture002` の Hidden 診断期待値を作ります。
+- `ExpectedLayerDependencyDetail`
+  - `Resources.LayerDependencyDisallowedReference` を使って、レイヤー診断の詳細理由を生成します。
+- `InMemoryAnalyzerConfigOptions`
+  - `OptionValues` の allowed roots 正規化など、オプション読み取りロジックの直接テストに使います。
+
+重大度は `interactionflow_mode` に合わせて `.editorconfig` の
+`dotnet_diagnostic.<ID>.severity` も同時に設定します。
+
+## レイヤー依存関係規則のテスト
+
+### レイヤー間依存
+
+管理対象レイヤー間の許可・禁止を検証します。
+
+- `SystemFlows` から `ExternalPorts` / `Externals` / `Builders` への禁止依存
+- `Interactions` から `SystemFlows` / `Externals` / `Builders` への禁止依存
+- `ExternalPorts` から `SystemFlows` / `Interactions` / `Externals` / `Builders` への禁止依存
+- `Entities` から他の管理対象レイヤーへの禁止依存
+- 各レイヤーから許可された管理対象レイヤーへの依存が診断されないこと
+
+### 外部 namespace
+
+管理対象外 namespace への依存について、以下を検証します。
+
+- `Interactions` などから許可されていない外部 namespace へ依存すると診断されること
+- `System` は既定で許可されること
+- `interactionflow_allowed_roots` に指定した root と子 namespace は許可されること
+- `ThirdParty` と `ThirdPartyX` のような部分一致は許可されないこと
+- `Builders` からの外部依存は診断されないこと
+
+### 参照形状
+
+定義側と使用側のさまざまな C# 形状から依存先型を検出できることを検証します。
+
+- メソッド戻り値型
+- メソッド引数型
+- 型パラメータ制約
+- 基底クラス
+- interface 実装
+- フィールド型
+- プロパティ型
+- オブジェクト生成
+- メソッド呼び出し
+- フィールド参照
+- プロパティ参照
+- ローカル変数宣言
+
+### 複合型と重複診断
+
+型の再帰検査と重複抑制を検証します。
+
+- ジェネリック型引数内に同じ禁止型が複数回現れても 1 件だけ診断すること
+- `Nullable<T>` や配列の内側にある禁止型を診断すること
+- タプル、匿名型、ラムダ、ローカル関数などを含む許可済み依存を誤診断しないこと
+- global namespace を持つ合成型を外部依存として誤診断しないこと
+
+### オプション
+
+Analyzer オプションの動作を検証します。
+
+- `interactionflow_enabled = False` で診断しないこと
+- `interactionflow_mode = Error` で Error 診断になること
+- 不正な `interactionflow_mode` は Warning にフォールバックすること
+- `interactionflow_allowed_roots` は大文字小文字非依存で重複を正規化すること
+
+## IDependencyNode 宣言規則のテスト
+
+テスト内で最小の
+`InteractionFlow.Core.Entities.Architectures.IDependencyNode` 定義を追加し、
+Analyzer が metadata name で対象 interface を解決できるようにしています。
+
+### 正常系
+
+以下のケースで診断しないことを検証します。
+
+- 通常コンストラクタで受け取った `IDependencyNode` 系引数を、`Dependency` が返す配列に含める
+- プライマリコンストラクタで受け取った `IDependencyNode` 系引数を、`Dependency` が返す配列に含める
+- 通常コンストラクタ内で `Dependency` auto-property に直接代入する
+- `sealed` class が `params IDependencyNode[] dependency` を持たない
+
+### 欠落検出
+
+以下のケースで `InteractionFlowArchitecture002` を診断することを検証します。
+
+- 通常コンストラクタで受け取った `IDependencyNode` 系引数が `Dependency` に含まれない
+- `IDependencyNode` 実装 class を継承するプライマリコンストラクタで、引数を基底コンストラクタへ渡さない
+- `abstract` class のコンストラクタに `params IDependencyNode[] dependency` がない
+- `sealed` ではない具象 class のコンストラクタに `params IDependencyNode[] dependency` がない
+
+### ローカライズ
+
+`DependencyNodeResources_LocalizesMessages` で、`Resources.Culture` を切り替え、
+Dependency Node 系メッセージが英語・日本語で取得できることを確認します。
+
+## 実行方法
+
+Analyzer テストだけを実行する場合:
+
+```powershell
+dotnet test InteractionFlow.Analyzers.Tests/InteractionFlow.Analyzers.Tests.csproj
+```
+
+ソリューション全体で確認する場合:
+
+```powershell
+dotnet build InteractionFlow.slnx
+dotnet test InteractionFlow.slnx
+```

--- a/InteractionFlow.Analyzers.Tests/UnitTest1.cs
+++ b/InteractionFlow.Analyzers.Tests/UnitTest1.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 using System;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
@@ -65,6 +66,32 @@ public class InteractionFlowAnalyzersAnalyzerTests
         Assert.Contains("thirdparty", roots, StringComparer.OrdinalIgnoreCase);
         Assert.Single(roots, x => x.Equals("thirdparty", StringComparison.OrdinalIgnoreCase));
         Assert.False(LayerNames.IsDisallowReference(roots, "App.Interactions", "ThirdParty.Lib", out _, out _));
+    }
+
+    /// <summary>
+    /// Dependency Node ルールの診断メッセージが Resources 経由で英語・日本語に切り替わることを確認します。
+    /// </summary>
+    [Fact]
+    public void DependencyNodeResources_LocalizesMessages()
+    {
+        var previousCulture = Resources.Culture;
+
+        try
+        {
+            Resources.Culture = CultureInfo.GetCultureInfo("en");
+            Assert.Equal(
+                "IDependencyNode class must be sealed or declare 'params IDependencyNode[] dependency'",
+                Resources.DependencyNodeMustBeSealedOrHaveParams);
+
+            Resources.Culture = CultureInfo.GetCultureInfo("ja");
+            Assert.Equal(
+                "IDependencyNode クラスは sealed にするか 'params IDependencyNode[] dependency' を宣言する必要があります",
+                Resources.DependencyNodeMustBeSealedOrHaveParams);
+        }
+        finally
+        {
+            Resources.Culture = previousCulture;
+        }
     }
 
     /// <summary>

--- a/InteractionFlow.Analyzers.Tests/UnitTest1.cs
+++ b/InteractionFlow.Analyzers.Tests/UnitTest1.cs
@@ -44,7 +44,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
 
         var expected = new DiagnosticResult(InteractionFlowAnalyzersAnalyzer.DiagnosticId, DiagnosticSeverity.Hidden)
             .WithSpan(7, 13, 7, 49)
-            .WithArguments("Interactions", "Builders", "BuilderWorker");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderWorker"));
 
         await VerifyAsync(useCaseSource, additionalSources: [("BuilderWorker.cs", workerSource)], expected: expected);
     }
@@ -122,7 +122,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
 
         var expected = new DiagnosticResult(InteractionFlowAnalyzersAnalyzer.DiagnosticId, DiagnosticSeverity.Hidden)
             .WithSpan(14, 79, 14, 82)
-            .WithArguments("Interactions", "Builders", "BuilderType");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderType"));
 
         await VerifyAsync(source, expected);
     }
@@ -227,7 +227,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
 
         var expected = new DiagnosticResult(InteractionFlowAnalyzersAnalyzer.DiagnosticId, DiagnosticSeverity.Hidden)
             .WithSpan(12, 34, 12, 40)
-            .WithArguments("Interactions", "ThirdParty", "Client");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "ThirdParty", "Client"));
 
         await VerifyAsync(source, expected);
     }
@@ -260,7 +260,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(12, 22 + targetLayer.Length + targetType.Length, 12, 32 + targetLayer.Length + targetType.Length)
-            .WithArguments("SystemFlows", targetLayer, targetType);
+            .WithArguments(ExpectedLayerDependencyDetail("SystemFlows", targetLayer, targetType));
 
         await VerifyAsync(source, expected);
     }
@@ -293,7 +293,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(12, 22 + targetLayer.Length + targetType.Length, 12, 32 + targetLayer.Length + targetType.Length)
-            .WithArguments("Interactions", targetLayer, targetType);
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", targetLayer, targetType));
 
         await VerifyAsync(source, expected);
     }
@@ -327,7 +327,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(12, 15 + targetLayer.Length + targetType.Length, 12, 21 + targetLayer.Length + targetType.Length)
-            .WithArguments("ExternalPorts", targetLayer, targetType);
+            .WithArguments(ExpectedLayerDependencyDetail("ExternalPorts", targetLayer, targetType));
 
         await VerifyAsync(source, expected);
     }
@@ -363,7 +363,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(12, 22 + targetNamespace.Length + targetType.Length, 12, 32 + targetNamespace.Length + targetType.Length)
-            .WithArguments("Entities", targetShowName, targetType);
+            .WithArguments(ExpectedLayerDependencyDetail("Entities", targetShowName, targetType));
 
         await VerifyAsync(source, expected);
     }
@@ -462,7 +462,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(12, 43, 12, 49)
-            .WithArguments("Interactions", "Builders", "BuilderWorker");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderWorker"));
 
         await VerifyAsync(source, expected);
     }
@@ -491,7 +491,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(10, 18, 10, 25)
-            .WithArguments("Interactions", "Builders", "BuilderWorker");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderWorker"));
 
         await VerifyAsync(source, expected);
     }
@@ -520,7 +520,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(10, 18, 10, 25)
-            .WithArguments("Interactions", "Builders", "BuilderBase");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderBase"));
 
         await VerifyAsync(source, expected);
     }
@@ -549,7 +549,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(10, 18, 10, 25)
-            .WithArguments("Interactions", "Builders", "IBuilderContract");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "IBuilderContract"));
 
         await VerifyAsync(source, expected);
     }
@@ -579,7 +579,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(12, 44, 12, 54)
-            .WithArguments("Interactions", "Builders", "BuilderWorker");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderWorker"));
 
         await VerifyAsync(source, expected);
     }
@@ -611,7 +611,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(12, 21, 12, 24)
-            .WithArguments("Interactions", "Builders", "BuilderWorker");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderWorker"));
 
         await VerifyAsync(source, expected);
     }
@@ -644,7 +644,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(14, 20, 14, 52)
-            .WithArguments("Interactions", "Builders", "BuilderWorker");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderWorker"));
 
         await VerifyAsync(source, expected);
     }
@@ -678,7 +678,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(15, 20, 15, 51)
-            .WithArguments("Interactions", "Builders", "BuilderWorker");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderWorker"));
 
         await VerifyAsync(source, expected);
     }
@@ -712,7 +712,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(15, 20, 15, 51)
-            .WithArguments("Interactions", "Builders", "BuilderWorker");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderWorker"));
 
         await VerifyAsync(source, expected);
     }
@@ -745,7 +745,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(14, 40, 14, 57)
-            .WithArguments("Interactions", "Builders", "BuilderWorker");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderWorker"));
 
         await VerifyAsync(source, expected);
     }
@@ -803,7 +803,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
 
         var expected = new DiagnosticResult(InteractionFlowAnalyzersAnalyzer.DiagnosticId, DiagnosticSeverity.Error)
             .WithSpan(12, 43, 12, 53)
-            .WithArguments("Interactions", "Builders", "BuilderWorker");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderWorker"));
 
         await VerifyAsync(source, mode: "Error", expected: expected);
     }
@@ -834,7 +834,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
 
         var expected = new DiagnosticResult(InteractionFlowAnalyzersAnalyzer.DiagnosticId, DiagnosticSeverity.Warning)
             .WithSpan(12, 43, 12, 53)
-            .WithArguments("Interactions", "Builders", "BuilderWorker");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderWorker"));
 
         await VerifyAsync(source, mode: "Banana", expected: expected);
     }
@@ -911,7 +911,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedHidden(12, 35, 12, 41)
-            .WithArguments("Interactions", "ThirdPartyX", "Client");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "ThirdPartyX", "Client"));
 
         await VerifyAsync(source, additionalSources: null, allowedRoots: "ThirdParty", expected: expected);
     }
@@ -949,9 +949,9 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expectedNullable = ExpectedHidden(18, 43, 18, 48)
-            .WithArguments("Interactions", "Builders", "BuilderValue");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderValue"));
         var expectedArray = ExpectedHidden(20, 45, 20, 50)
-            .WithArguments("Interactions", "Builders", "BuilderWorker");
+            .WithArguments(ExpectedLayerDependencyDetail("Interactions", "Builders", "BuilderWorker"));
 
         await VerifyAsync(source, expectedNullable, expectedArray);
     }
@@ -1279,6 +1279,9 @@ public class InteractionFlowAnalyzersAnalyzerTests
 
         await VerifyAsync(source, expected);
     }
+
+    private static string ExpectedLayerDependencyDetail(string sourceLayer, string targetLayer, string typeName)
+        => string.Format(Resources.LayerDependencyDisallowedReference, sourceLayer, targetLayer, typeName);
 
     private static DiagnosticResult ExpectedHidden(int startLine, int startColumn, int endLine, int endColumn)
         => new DiagnosticResult(InteractionFlowAnalyzersAnalyzer.DiagnosticId, DiagnosticSeverity.Hidden)

--- a/InteractionFlow.Analyzers.Tests/UnitTest1.cs
+++ b/InteractionFlow.Analyzers.Tests/UnitTest1.cs
@@ -972,6 +972,42 @@ public class InteractionFlowAnalyzersAnalyzerTests
     }
 
     /// <summary>
+    /// 通常コンストラクタで IDependencyNode 系の引数を Dependency auto-property に直接代入している場合、
+    /// Dependency Node ルールが診断しないことを確認します。
+    /// </summary>
+    [Fact]
+    public async Task DependencyNode_NormalConstructor_AssignsDependencyProperty_DoNotReport()
+    {
+        var source = """
+            using System;
+            using InteractionFlow.Core.Entities.Architectures;
+
+            namespace InteractionFlow.Core.Entities.Architectures
+            {
+                public interface IDependencyNode
+                {
+                    ReadOnlyMemory<IDependencyNode> Dependency { get; }
+                }
+            }
+
+            namespace App.Nodes
+            {
+                public class Test : IDependencyNode
+                {
+                    public Test(IDependencyNode node1)
+                    {
+                        Dependency = new IDependencyNode[] { node1 };
+                    }
+
+                    public ReadOnlyMemory<IDependencyNode> Dependency { get; }
+                }
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    /// <summary>
     /// 通常コンストラクタで受け取った IDependencyNode 系の引数が Dependency に含まれていない場合、
     /// 欠落した引数を診断することを確認します。
     /// </summary>

--- a/InteractionFlow.Analyzers.Tests/UnitTest1.cs
+++ b/InteractionFlow.Analyzers.Tests/UnitTest1.cs
@@ -2,8 +2,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 using System;
-using System.Globalization;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 using Xunit;
 namespace InteractionFlow.Analyzers.Tests;
@@ -87,6 +87,45 @@ public class InteractionFlowAnalyzersAnalyzerTests
             Assert.Equal(
                 "IDependencyNode クラスは sealed にするか 'params IDependencyNode[] dependency' を宣言する必要があります",
                 Resources.DependencyNodeMustBeSealedOrHaveParams);
+        }
+        finally
+        {
+            Resources.Culture = previousCulture;
+        }
+    }
+
+    /// <summary>
+    /// Analyzer の共通文と詳細理由を組み合わせた診断メッセージが、
+    /// Resources 経由で英語・日本語に切り替わることを確認します。
+    /// </summary>
+    [Fact]
+    public void AnalyzerResources_ComposesCommonMessagesAndDetails()
+    {
+        var previousCulture = Resources.Culture;
+
+        try
+        {
+            Resources.Culture = CultureInfo.GetCultureInfo("en");
+            var layerDetail = string.Format(Resources.LayerDependencyDisallowedReference, "Interactions", "Builders", "BuilderWorker");
+            var dependencyNodeDetail = string.Format(Resources.DependencyNodeParameterMustBeIncludedInDependency, "node1");
+
+            Assert.Equal(
+                "Invalid layer dependency: Layer 'Interactions' must not depend on 'Builders'; referenced type: 'BuilderWorker'",
+                string.Format(Resources.LayerDependencyAnalyzerMessageFormat, layerDetail));
+            Assert.Equal(
+                "Invalid dependency node declaration: Parameter 'node1' must be included in Dependency",
+                string.Format(Resources.DependencyNodeAnalyzerMessageFormat, dependencyNodeDetail));
+
+            Resources.Culture = CultureInfo.GetCultureInfo("ja");
+            layerDetail = string.Format(Resources.LayerDependencyDisallowedReference, "Interactions", "Builders", "BuilderWorker");
+            dependencyNodeDetail = string.Format(Resources.DependencyNodeParameterMustBeIncludedInDependency, "node1");
+
+            Assert.Equal(
+                "レイヤー依存関係規則に違反しています: 'Interactions' は 'Builders' に依存できません。参照型: 'BuilderWorker'",
+                string.Format(Resources.LayerDependencyAnalyzerMessageFormat, layerDetail));
+            Assert.Equal(
+                "依存ノード宣言規則に違反しています: 引数 'node1' は Dependency に含める必要があります",
+                string.Format(Resources.DependencyNodeAnalyzerMessageFormat, dependencyNodeDetail));
         }
         finally
         {
@@ -1032,6 +1071,41 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         await VerifyAsync(source);
+    }
+
+    /// <summary>
+    /// IDependencyNode.Dependency を明示的に実装している場合、
+    /// 同名の公開 Dependency プロパティではなく interface 実装側を検査することを確認します。
+    /// </summary>
+    [Fact]
+    public async Task DependencyNode_ExplicitDependencyProperty_IgnoresSameNamePublicProperty()
+    {
+        var source = """
+            using System;
+            using InteractionFlow.Core.Entities.Architectures;
+
+            namespace InteractionFlow.Core.Entities.Architectures
+            {
+                public interface IDependencyNode
+                {
+                    ReadOnlyMemory<IDependencyNode> Dependency { get; }
+                }
+            }
+
+            namespace App.Nodes
+            {
+                public sealed class Test(IDependencyNode node1) : IDependencyNode
+                {
+                    public ReadOnlyMemory<IDependencyNode> Dependency => new IDependencyNode[] { node1 };
+
+                    ReadOnlyMemory<IDependencyNode> IDependencyNode.Dependency => ReadOnlyMemory<IDependencyNode>.Empty;
+                }
+            }
+            """;
+
+        var expected = ExpectedDependencyHidden(14, 46, 14, 51);
+
+        await VerifyAsync(source, expected);
     }
 
     /// <summary>

--- a/InteractionFlow.Analyzers.Tests/UnitTest1.cs
+++ b/InteractionFlow.Analyzers.Tests/UnitTest1.cs
@@ -992,7 +992,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
 
             namespace App.Nodes
             {
-                public class Test : IDependencyNode
+                public sealed class Test : IDependencyNode
                 {
                     public Test(IDependencyNode node1)
                     {
@@ -1000,6 +1000,44 @@ public class InteractionFlowAnalyzersAnalyzerTests
                     }
 
                     public ReadOnlyMemory<IDependencyNode> Dependency { get; }
+                }
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    /// <summary>
+    /// sealed な IDependencyNode 実装クラスの通常コンストラクタに params IDependencyNode[] が無い場合でも、
+    /// 継承拡張対象外として診断しないことを確認します。
+    /// </summary>
+    [Fact]
+    public async Task DependencyNode_SealedConstructor_MissingParams_DoNotReport()
+    {
+        var source = """
+            using System;
+            using InteractionFlow.Core.Entities.Architectures;
+
+            namespace InteractionFlow.Core.Entities.Architectures
+            {
+                public interface IDependencyNode
+                {
+                    ReadOnlyMemory<IDependencyNode> Dependency { get; }
+                }
+            }
+
+            namespace App.Nodes
+            {
+                public sealed class NodeClass : IDependencyNode
+                {
+                    private readonly IDependencyNode[] dependency;
+
+                    public NodeClass(IDependencyNode node1)
+                    {
+                        dependency = [node1];
+                    }
+
+                    public ReadOnlyMemory<IDependencyNode> Dependency => dependency;
                 }
             }
             """;
@@ -1171,6 +1209,46 @@ public class InteractionFlowAnalyzersAnalyzerTests
             """;
 
         var expected = ExpectedDependencyHidden(22, 16, 22, 25);
+
+        await VerifyAsync(source, expected);
+    }
+
+    /// <summary>
+    /// sealed ではない具象 IDependencyNode 実装クラスの通常コンストラクタに
+    /// params IDependencyNode[] が無い場合、診断することを確認します。
+    /// </summary>
+    [Fact]
+    public async Task DependencyNode_NonSealedConstructor_MissingParams_Reports()
+    {
+        var source = """
+            using System;
+            using InteractionFlow.Core.Entities.Architectures;
+
+            namespace InteractionFlow.Core.Entities.Architectures
+            {
+                public interface IDependencyNode
+                {
+                    ReadOnlyMemory<IDependencyNode> Dependency { get; }
+                }
+            }
+
+            namespace App.Nodes
+            {
+                public class NodeClass : IDependencyNode
+                {
+                    private readonly IDependencyNode[] dependency;
+
+                    public NodeClass(IDependencyNode node1)
+                    {
+                        this.dependency = [node1];
+                    }
+
+                    public ReadOnlyMemory<IDependencyNode> Dependency => dependency;
+                }
+            }
+            """;
+
+        var expected = ExpectedDependencyHidden(18, 16, 18, 25);
 
         await VerifyAsync(source, expected);
     }

--- a/InteractionFlow.Analyzers.Tests/UnitTest1.cs
+++ b/InteractionFlow.Analyzers.Tests/UnitTest1.cs
@@ -929,8 +929,222 @@ public class InteractionFlowAnalyzersAnalyzerTests
         await VerifyAsync(source, expectedNullable, expectedArray);
     }
 
+    /// <summary>
+    /// 通常コンストラクタで受け取った IDependencyNode 系の引数を Dependency が返す配列へ含めている場合、
+    /// Dependency Node ルールが診断しないことを確認します。
+    /// </summary>
+    [Fact]
+    public async Task DependencyNode_NormalConstructor_IncludesDependencies_DoNotReport()
+    {
+        var source = """
+            using System;
+            using InteractionFlow.Core.Entities.Architectures;
+
+            namespace InteractionFlow.Core.Entities.Architectures
+            {
+                public interface IDependencyNode
+                {
+                    ReadOnlyMemory<IDependencyNode> Dependency { get; }
+                }
+            }
+
+            namespace App.Nodes
+            {
+                public interface IPort : IDependencyNode
+                {
+                }
+
+                public abstract class NodeClass : IDependencyNode
+                {
+                    private readonly IDependencyNode[] dependency;
+
+                    public NodeClass(IPort node1, IDependencyNode node2, params IDependencyNode[] dependency)
+                    {
+                        this.dependency = [node1, node2, .. dependency];
+                    }
+
+                    public ReadOnlyMemory<IDependencyNode> Dependency => dependency;
+                }
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    /// <summary>
+    /// 通常コンストラクタで受け取った IDependencyNode 系の引数が Dependency に含まれていない場合、
+    /// 欠落した引数を診断することを確認します。
+    /// </summary>
+    [Fact]
+    public async Task DependencyNode_NormalConstructor_MissingDependency_Reports()
+    {
+        var source = """
+            using System;
+            using InteractionFlow.Core.Entities.Architectures;
+
+            namespace InteractionFlow.Core.Entities.Architectures
+            {
+                public interface IDependencyNode
+                {
+                    ReadOnlyMemory<IDependencyNode> Dependency { get; }
+                }
+            }
+
+            namespace App.Nodes
+            {
+                public interface IPort : IDependencyNode
+                {
+                }
+
+                public abstract class NodeClass : IDependencyNode
+                {
+                    private readonly IDependencyNode[] dependency;
+
+                    public NodeClass(IPort node1, params IDependencyNode[] dependency)
+                    {
+                        this.dependency = [.. dependency];
+                    }
+
+                    public ReadOnlyMemory<IDependencyNode> Dependency => dependency;
+                }
+            }
+            """;
+
+        var expected = ExpectedDependencyHidden(22, 32, 22, 37);
+
+        await VerifyAsync(source, expected);
+    }
+
+    /// <summary>
+    /// プライマリコンストラクタで受け取った IDependencyNode 系の引数を Dependency が返す配列へ含めている場合、
+    /// Dependency Node ルールが診断しないことを確認します。
+    /// </summary>
+    [Fact]
+    public async Task DependencyNode_PrimaryConstructor_IncludesDependencies_DoNotReport()
+    {
+        var source = """
+            using System;
+            using InteractionFlow.Core.Entities.Architectures;
+
+            namespace InteractionFlow.Core.Entities.Architectures
+            {
+                public interface IDependencyNode
+                {
+                    ReadOnlyMemory<IDependencyNode> Dependency { get; }
+                }
+            }
+
+            namespace App.Nodes
+            {
+                public interface IPort : IDependencyNode
+                {
+                }
+
+                public abstract class NodeClass(IPort node1, params IDependencyNode[] dependency) : IDependencyNode
+                {
+                    private readonly IDependencyNode[] dependencies = [node1, .. dependency];
+
+                    public ReadOnlyMemory<IDependencyNode> Dependency => dependencies;
+                }
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    /// <summary>
+    /// IDependencyNode 実装クラスを継承するプライマリコンストラクタで、
+    /// 親へ流していない IDependencyNode 系の引数を診断することを確認します。
+    /// </summary>
+    [Fact]
+    public async Task DependencyNode_PrimaryConstructor_MissingBaseForward_Reports()
+    {
+        var source = """
+            using System;
+            using InteractionFlow.Core.Entities.Architectures;
+
+            namespace InteractionFlow.Core.Entities.Architectures
+            {
+                public interface IDependencyNode
+                {
+                    ReadOnlyMemory<IDependencyNode> Dependency { get; }
+                }
+            }
+
+            namespace App.Nodes
+            {
+                public interface IPort : IDependencyNode
+                {
+                }
+
+                public abstract class BaseNode(params IDependencyNode[] dependency) : IDependencyNode
+                {
+                    private readonly IDependencyNode[] dependencies = dependency;
+
+                    public ReadOnlyMemory<IDependencyNode> Dependency => dependencies;
+                }
+
+                public abstract class ChildNode(IPort node1, params IDependencyNode[] dependency) : BaseNode(dependency)
+                {
+                }
+            }
+            """;
+
+        var expected = ExpectedDependencyHidden(25, 43, 25, 48);
+
+        await VerifyAsync(source, expected);
+    }
+
+    /// <summary>
+    /// 継承拡張される抽象 IDependencyNode クラスの通常コンストラクタに
+    /// params IDependencyNode[] が無い場合、診断することを確認します。
+    /// </summary>
+    [Fact]
+    public async Task DependencyNode_AbstractConstructor_MissingParams_Reports()
+    {
+        var source = """
+            using System;
+            using InteractionFlow.Core.Entities.Architectures;
+
+            namespace InteractionFlow.Core.Entities.Architectures
+            {
+                public interface IDependencyNode
+                {
+                    ReadOnlyMemory<IDependencyNode> Dependency { get; }
+                }
+            }
+
+            namespace App.Nodes
+            {
+                public interface IPort : IDependencyNode
+                {
+                }
+
+                public abstract class NodeClass : IDependencyNode
+                {
+                    private readonly IDependencyNode[] dependency;
+
+                    public NodeClass(IPort node1)
+                    {
+                        this.dependency = [node1];
+                    }
+
+                    public ReadOnlyMemory<IDependencyNode> Dependency => dependency;
+                }
+            }
+            """;
+
+        var expected = ExpectedDependencyHidden(22, 16, 22, 25);
+
+        await VerifyAsync(source, expected);
+    }
+
     private static DiagnosticResult ExpectedHidden(int startLine, int startColumn, int endLine, int endColumn)
         => new DiagnosticResult(InteractionFlowAnalyzersAnalyzer.DiagnosticId, DiagnosticSeverity.Hidden)
+            .WithSpan(startLine, startColumn, endLine, endColumn);
+
+    private static DiagnosticResult ExpectedDependencyHidden(int startLine, int startColumn, int endLine, int endColumn)
+        => new DiagnosticResult(InteractionFlowAnalyzersAnalyzer.DependencyNodeDiagnosticId, DiagnosticSeverity.Hidden)
             .WithSpan(startLine, startColumn, endLine, endColumn);
 
     private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
@@ -967,6 +1181,7 @@ public class InteractionFlowAnalyzersAnalyzerTests
             {OptionValues.Keys.interactionflow_mode} = {mode}
             {allowedRootsOption}
             dotnet_diagnostic.{InteractionFlowAnalyzersAnalyzer.DiagnosticId}.severity = {diagnosticSeverity}
+            dotnet_diagnostic.{InteractionFlowAnalyzersAnalyzer.DependencyNodeDiagnosticId}.severity = {diagnosticSeverity}
 
             """;
 

--- a/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
+++ b/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
@@ -350,14 +350,14 @@ namespace InteractionFlow.Analyzers
             {
                 context.CancellationToken.ThrowIfCancellationRequested();
 
-                if (type.IsAbstract && !HasParamsDependencyNodeParameter(constructor, dependencyNode))
+                if (!type.IsSealed && !HasParamsDependencyNodeParameter(constructor, dependencyNode))
                 {
                     var location = GetConstructorDiagnosticLocation(constructor, typeLocation);
                     ReportDependencyNodeDiagnostic(
                         context,
                         analysisState,
                         location,
-                        "IDependencyNode abstract class constructor must declare 'params IDependencyNode[] dependency' for derived dependency extension.");
+                        "IDependencyNode class must be sealed or declare 'params IDependencyNode[] dependency' for derived dependency extension.");
                 }
 
                 foreach (var parameter in constructor.Parameters.Where(e => IsDependencyParameter(e, dependencyNode)))

--- a/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
+++ b/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
@@ -29,7 +29,7 @@ namespace InteractionFlow.Analyzers
         public const string DependencyNodeDiagnosticId = "InteractionFlowArchitecture002";
 
         private static readonly LocalizableString LayerDependencyAnalyzerTitle =
-    new LocalizableResourceString(nameof(Resources.LayerDependencyAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+            new LocalizableResourceString(nameof(Resources.LayerDependencyAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
 
         private static readonly LocalizableString LayerDependencyAnalyzerMessageFormat =
             new LocalizableResourceString(nameof(Resources.LayerDependencyAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
@@ -548,10 +548,23 @@ namespace InteractionFlow.Analyzers
 
         private static bool IsDependencyProperty(IPropertySymbol property, INamedTypeSymbol dependencyNode)
         {
-            return property.Name == "Dependency" ||
-                property.ExplicitInterfaceImplementations.Any(e =>
-                    e.Name == "Dependency" &&
-                    SymbolEqualityComparer.Default.Equals(e.ContainingType, dependencyNode));
+            var dependencyProperty = dependencyNode.GetMembers("Dependency")
+                .OfType<IPropertySymbol>()
+                .FirstOrDefault(e => e.Parameters.Length == 0);
+
+            if (dependencyProperty == null)
+            {
+                return false;
+            }
+
+            if (property.ExplicitInterfaceImplementations.Any(e =>
+                SymbolEqualityComparer.Default.Equals(e, dependencyProperty)))
+            {
+                return true;
+            }
+
+            var implementation = property.ContainingType.FindImplementationForInterfaceMember(dependencyProperty);
+            return SymbolEqualityComparer.Default.Equals(implementation, property);
         }
 
         private static IEnumerable<ISymbol> GetReferencedMemberSymbols(

--- a/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
+++ b/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
@@ -46,11 +46,6 @@ namespace InteractionFlow.Analyzers
         private static readonly LocalizableString DependencyNodeAnalyzerDescription =
             new LocalizableResourceString(nameof(Resources.DependencyNodeAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
 
-        // You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
-        // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Localizing%20Analyzers.md for more on localization
-        //private static readonly LocalizableString Title = "Invalid layer dependency";
-        //private static readonly LocalizableString MessageFormat = "Layer '{0}' must not depend on '{1}' (Type = '{2}')";
-        //private static readonly LocalizableString Description = "Interaction Flow Architecture - Invalid layer dependency";
         private const string Category = "Architecture";
 
         private static readonly DiagnosticDescriptor Rule = new(

--- a/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
+++ b/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
@@ -489,7 +489,10 @@ namespace InteractionFlow.Analyzers
             {
                 context.CancellationToken.ThrowIfCancellationRequested();
 
-                var referencedMembers = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+                var referencedMembers = new HashSet<ISymbol>(SymbolEqualityComparer.Default)
+                {
+                    property
+                };
 
                 foreach (var syntaxReference in property.DeclaringSyntaxReferences)
                 {
@@ -583,7 +586,7 @@ namespace InteractionFlow.Analyzers
             {
                 context.CancellationToken.ThrowIfCancellationRequested();
 
-                if (!(syntaxReference.GetSyntax(context.CancellationToken) is ConstructorDeclarationSyntax constructorDeclaration))
+                if (syntaxReference.GetSyntax(context.CancellationToken) is not ConstructorDeclarationSyntax constructorDeclaration)
                 {
                     continue;
                 }

--- a/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
+++ b/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using System;
@@ -22,6 +23,11 @@ namespace InteractionFlow.Analyzers
         /// </summary>
         public const string DiagnosticId = "InteractionFlowArchitecture001";
 
+        /// <summary>
+        /// The diagnostic identifier for incomplete IDependencyNode dependency declarations.
+        /// </summary>
+        public const string DependencyNodeDiagnosticId = "InteractionFlowArchitecture002";
+
         private static readonly LocalizableString Title =
     new LocalizableResourceString(nameof(Resources.AnalyzerTitle), Resources.ResourceManager, typeof(Resources));
 
@@ -39,6 +45,14 @@ namespace InteractionFlow.Analyzers
         private const string Category = "Architecture";
 
         private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+        private static readonly DiagnosticDescriptor DependencyNodeRule = new(
+            DependencyNodeDiagnosticId,
+            "Incomplete dependency node declaration",
+            "{0}",
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "IDependencyNode constructor dependencies must be exposed through Dependency or passed to the base dependency node.");
 
         private static readonly ImmutableDictionary<DiagnosticSeverity, DiagnosticDescriptor> RulesBySeverity =
             Enum.GetValues(typeof(DiagnosticSeverity))
@@ -47,14 +61,33 @@ namespace InteractionFlow.Analyzers
                     severity => severity,
                     severity => new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, severity, isEnabledByDefault: true, description: Description));
 
+        private static readonly ImmutableDictionary<DiagnosticSeverity, DiagnosticDescriptor> DependencyNodeRulesBySeverity =
+            Enum.GetValues(typeof(DiagnosticSeverity))
+                .Cast<DiagnosticSeverity>()
+                .ToImmutableDictionary(
+                    severity => severity,
+                    severity => new DiagnosticDescriptor(
+                        DependencyNodeDiagnosticId,
+                        DependencyNodeRule.Title,
+                        DependencyNodeRule.MessageFormat,
+                        Category,
+                        severity,
+                        isEnabledByDefault: true,
+                        description: DependencyNodeRule.Description));
+
         private static DiagnosticDescriptor GetRule(DiagnosticSeverity severity)
         {
             return RulesBySeverity.TryGetValue(severity, out var rule) ? rule : Rule;
         }
 
+        private static DiagnosticDescriptor GetDependencyNodeRule(DiagnosticSeverity severity)
+        {
+            return DependencyNodeRulesBySeverity.TryGetValue(severity, out var rule) ? rule : DependencyNodeRule;
+        }
+
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-               => ImmutableArray.Create(Rule);
+               => ImmutableArray.Create(Rule, DependencyNodeRule);
 
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
@@ -64,7 +97,9 @@ namespace InteractionFlow.Analyzers
 
             context.RegisterCompilationStartAction(compilationContext =>
             {
-                var analysisState = new CompilationAnalyzerContext(compilationContext.Options.AnalyzerConfigOptionsProvider);
+                var analysisState = new CompilationAnalyzerContext(
+                    compilationContext.Compilation,
+                    compilationContext.Options.AnalyzerConfigOptionsProvider);
 
                 // ▼ 定義側
                 compilationContext.RegisterSymbolAction(context => AnalyzeProperty(context, analysisState), SymbolKind.Property);
@@ -132,6 +167,8 @@ namespace InteractionFlow.Analyzers
 
                 CheckTypeRecursive(analysisContext, iface);
             }
+
+            AnalyzeDependencyNodeType(context, type, analysisState);
         }
 
         private static void AnalyzeMethod(SymbolAnalysisContext context, CompilationAnalyzerContext analysisState)
@@ -280,6 +317,347 @@ namespace InteractionFlow.Analyzers
         }
 
         // =========================
+        // Dependency Node
+        // =========================
+
+        private static void AnalyzeDependencyNodeType(
+            SymbolAnalysisContext context,
+            INamedTypeSymbol type,
+            CompilationAnalyzerContext analysisState)
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            var dependencyNode = analysisState.DependencyNodeType;
+            if (dependencyNode == null ||
+                type.TypeKind != TypeKind.Class ||
+                !IsDependencyNodeType(type, dependencyNode))
+            {
+                return;
+            }
+
+            var typeLocation = type.Locations.FirstOrDefault(loc => loc.IsInSource) ?? Location.None;
+            var options = analysisState.GetOptions(typeLocation);
+            if (!options.Enabled)
+            {
+                return;
+            }
+
+            var baseTypeIsDependencyNode = type.BaseType != null &&
+                type.BaseType.SpecialType != SpecialType.System_Object &&
+                IsDependencyNodeType(type.BaseType, dependencyNode);
+
+            foreach (var constructor in type.Constructors.Where(e => !e.IsStatic))
+            {
+                context.CancellationToken.ThrowIfCancellationRequested();
+
+                if (type.IsAbstract && !HasParamsDependencyNodeParameter(constructor, dependencyNode))
+                {
+                    var location = GetConstructorDiagnosticLocation(constructor, typeLocation);
+                    ReportDependencyNodeDiagnostic(
+                        context,
+                        analysisState,
+                        location,
+                        "IDependencyNode abstract class constructor must declare 'params IDependencyNode[] dependency' for derived dependency extension.");
+                }
+
+                foreach (var parameter in constructor.Parameters.Where(e => IsDependencyParameter(e, dependencyNode)))
+                {
+                    context.CancellationToken.ThrowIfCancellationRequested();
+
+                    if (baseTypeIsDependencyNode)
+                    {
+                        if (!ConstructorBaseCallIncludesParameter(context, analysisState, constructor, parameter))
+                        {
+                            ReportDependencyNodeDiagnostic(
+                                context,
+                                analysisState,
+                                GetParameterDiagnosticLocation(parameter, constructor, typeLocation),
+                                $"IDependencyNode constructor parameter '{parameter.Name}' must be passed to the base IDependencyNode constructor.");
+                        }
+                    }
+                    else if (!DependencyPropertyIncludesParameter(context, analysisState, type, dependencyNode, constructor, parameter))
+                    {
+                        ReportDependencyNodeDiagnostic(
+                            context,
+                            analysisState,
+                            GetParameterDiagnosticLocation(parameter, constructor, typeLocation),
+                            $"IDependencyNode constructor parameter '{parameter.Name}' must be included in Dependency.");
+                    }
+                }
+            }
+        }
+
+        private static bool IsDependencyParameter(IParameterSymbol parameter, INamedTypeSymbol dependencyNode)
+        {
+            return IsDependencyNodeType(parameter.Type, dependencyNode);
+        }
+
+        private static bool IsDependencyNodeType(ITypeSymbol type, INamedTypeSymbol dependencyNode)
+        {
+            if (type is IArrayTypeSymbol array)
+            {
+                return IsDependencyNodeType(array.ElementType, dependencyNode);
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(type, dependencyNode))
+            {
+                return true;
+            }
+
+            if (type is ITypeParameterSymbol typeParameter)
+            {
+                return typeParameter.ConstraintTypes.Any(e => IsDependencyNodeType(e, dependencyNode));
+            }
+
+            if (type is INamedTypeSymbol named)
+            {
+                return named.AllInterfaces.Any(e => SymbolEqualityComparer.Default.Equals(e, dependencyNode));
+            }
+
+            return false;
+        }
+
+        private static bool HasParamsDependencyNodeParameter(IMethodSymbol constructor, INamedTypeSymbol dependencyNode)
+        {
+            return constructor.Parameters.Any(parameter =>
+                parameter.IsParams &&
+                parameter.Type is IArrayTypeSymbol array &&
+                SymbolEqualityComparer.Default.Equals(array.ElementType, dependencyNode));
+        }
+
+        private static bool ConstructorBaseCallIncludesParameter(
+            SymbolAnalysisContext context,
+            CompilationAnalyzerContext analysisState,
+            IMethodSymbol constructor,
+            IParameterSymbol parameter)
+        {
+            foreach (var syntaxReference in constructor.DeclaringSyntaxReferences)
+            {
+                context.CancellationToken.ThrowIfCancellationRequested();
+
+                var syntax = syntaxReference.GetSyntax(context.CancellationToken);
+                var model = analysisState.GetSemanticModel(syntax.SyntaxTree);
+
+                if (syntax is ConstructorDeclarationSyntax constructorDeclaration)
+                {
+                    var initializer = constructorDeclaration.Initializer;
+                    if (initializer != null &&
+                        initializer.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.BaseConstructorInitializer) &&
+                        ContainsSymbolReference(initializer, parameter, model, context.CancellationToken))
+                    {
+                        return true;
+                    }
+                }
+                else if (syntax is TypeDeclarationSyntax typeDeclaration &&
+                    typeDeclaration.BaseList != null)
+                {
+                    foreach (var baseType in typeDeclaration.BaseList.Types)
+                    {
+                        context.CancellationToken.ThrowIfCancellationRequested();
+
+                        if (baseType.ToString().Contains("(") &&
+                            ContainsSymbolReference(baseType, parameter, model, context.CancellationToken))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool DependencyPropertyIncludesParameter(
+            SymbolAnalysisContext context,
+            CompilationAnalyzerContext analysisState,
+            INamedTypeSymbol type,
+            INamedTypeSymbol dependencyNode,
+            IMethodSymbol constructor,
+            IParameterSymbol parameter)
+        {
+            var dependencyProperties = type.GetMembers()
+                .OfType<IPropertySymbol>()
+                .Where(e => e.Parameters.Length == 0 && IsDependencyProperty(e, dependencyNode))
+                .ToImmutableArray();
+
+            if (dependencyProperties.Length == 0)
+            {
+                return false;
+            }
+
+            foreach (var property in dependencyProperties)
+            {
+                context.CancellationToken.ThrowIfCancellationRequested();
+
+                var referencedMembers = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+
+                foreach (var syntaxReference in property.DeclaringSyntaxReferences)
+                {
+                    context.CancellationToken.ThrowIfCancellationRequested();
+
+                    var syntax = syntaxReference.GetSyntax(context.CancellationToken);
+                    var model = analysisState.GetSemanticModel(syntax.SyntaxTree);
+
+                    if (ContainsSymbolReference(syntax, parameter, model, context.CancellationToken))
+                    {
+                        return true;
+                    }
+
+                    foreach (var referencedMember in GetReferencedMemberSymbols(syntax, model, type, context.CancellationToken))
+                    {
+                        referencedMembers.Add(referencedMember);
+                    }
+                }
+
+                foreach (var referencedMember in referencedMembers)
+                {
+                    context.CancellationToken.ThrowIfCancellationRequested();
+
+                    if (MemberDeclarationIncludesParameter(context, analysisState, referencedMember, parameter) ||
+                        ConstructorAssignmentIncludesParameter(context, analysisState, constructor, referencedMember, parameter))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsDependencyProperty(IPropertySymbol property, INamedTypeSymbol dependencyNode)
+        {
+            return property.Name == "Dependency" ||
+                property.ExplicitInterfaceImplementations.Any(e =>
+                    e.Name == "Dependency" &&
+                    SymbolEqualityComparer.Default.Equals(e.ContainingType, dependencyNode));
+        }
+
+        private static IEnumerable<ISymbol> GetReferencedMemberSymbols(
+            SyntaxNode syntax,
+            SemanticModel model,
+            INamedTypeSymbol containingType,
+            CancellationToken cancellationToken)
+        {
+            foreach (var node in syntax.DescendantNodesAndSelf())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var symbol = model.GetSymbolInfo(node, cancellationToken).Symbol;
+                if ((symbol is IFieldSymbol || symbol is IPropertySymbol) &&
+                    SymbolEqualityComparer.Default.Equals(symbol.ContainingType, containingType))
+                {
+                    yield return symbol;
+                }
+            }
+        }
+
+        private static bool MemberDeclarationIncludesParameter(
+            SymbolAnalysisContext context,
+            CompilationAnalyzerContext analysisState,
+            ISymbol member,
+            IParameterSymbol parameter)
+        {
+            foreach (var syntaxReference in member.DeclaringSyntaxReferences)
+            {
+                context.CancellationToken.ThrowIfCancellationRequested();
+
+                var syntax = syntaxReference.GetSyntax(context.CancellationToken);
+                var model = analysisState.GetSemanticModel(syntax.SyntaxTree);
+                if (ContainsSymbolReference(syntax, parameter, model, context.CancellationToken))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ConstructorAssignmentIncludesParameter(
+            SymbolAnalysisContext context,
+            CompilationAnalyzerContext analysisState,
+            IMethodSymbol constructor,
+            ISymbol targetMember,
+            IParameterSymbol parameter)
+        {
+            foreach (var syntaxReference in constructor.DeclaringSyntaxReferences)
+            {
+                context.CancellationToken.ThrowIfCancellationRequested();
+
+                if (!(syntaxReference.GetSyntax(context.CancellationToken) is ConstructorDeclarationSyntax constructorDeclaration))
+                {
+                    continue;
+                }
+
+                var body = (SyntaxNode?)constructorDeclaration.Body ?? constructorDeclaration.ExpressionBody;
+                if (body == null)
+                {
+                    continue;
+                }
+
+                var model = analysisState.GetSemanticModel(body.SyntaxTree);
+                foreach (var assignment in body.DescendantNodesAndSelf().OfType<AssignmentExpressionSyntax>())
+                {
+                    context.CancellationToken.ThrowIfCancellationRequested();
+
+                    var leftSymbol = model.GetSymbolInfo(assignment.Left, context.CancellationToken).Symbol;
+                    if (SymbolEqualityComparer.Default.Equals(leftSymbol, targetMember) &&
+                        ContainsSymbolReference(assignment.Right, parameter, model, context.CancellationToken))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ContainsSymbolReference(
+            SyntaxNode syntax,
+            ISymbol symbol,
+            SemanticModel model,
+            CancellationToken cancellationToken)
+        {
+            foreach (var node in syntax.DescendantNodesAndSelf())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var referencedSymbol = model.GetSymbolInfo(node, cancellationToken).Symbol;
+                if (SymbolEqualityComparer.Default.Equals(referencedSymbol, symbol))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static Location GetConstructorDiagnosticLocation(IMethodSymbol constructor, Location fallback)
+        {
+            return constructor.Locations.FirstOrDefault(loc => loc.IsInSource) ?? fallback;
+        }
+
+        private static Location GetParameterDiagnosticLocation(IParameterSymbol parameter, IMethodSymbol constructor, Location fallback)
+        {
+            return parameter.Locations.FirstOrDefault(loc => loc.IsInSource) ??
+                GetConstructorDiagnosticLocation(constructor, fallback);
+        }
+
+        private static void ReportDependencyNodeDiagnostic(
+            SymbolAnalysisContext context,
+            CompilationAnalyzerContext analysisState,
+            Location location,
+            string message)
+        {
+            var options = analysisState.GetOptions(location);
+            if (!options.Enabled)
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(GetDependencyNodeRule(options.Mode), location, message));
+        }
+
+        // =========================
         // 実行コンテキスト
         // =========================
 
@@ -313,11 +691,16 @@ namespace InteractionFlow.Analyzers
                 analysisState);
         }
 
-        private sealed class CompilationAnalyzerContext(AnalyzerConfigOptionsProvider optionsProvider)
+        private sealed class CompilationAnalyzerContext(Compilation compilation, AnalyzerConfigOptionsProvider optionsProvider)
         {
             private readonly OptionValues disabledOptions = new(null);
+            private readonly Compilation compilation = compilation;
             private readonly ConcurrentDictionary<SyntaxTree, OptionValues> optionsByTree = new();
+            private readonly ConcurrentDictionary<SyntaxTree, SemanticModel> semanticModelByTree = new();
             private readonly ConcurrentDictionary<string, DisallowReferenceInfo> disallowReferenceCache = new(StringComparer.Ordinal);
+
+            public INamedTypeSymbol? DependencyNodeType { get; } =
+                compilation.GetTypeByMetadataName("InteractionFlow.Core.Entities.Architectures.IDependencyNode");
 
             public OptionValues GetOptions(Location location)
             {
@@ -344,6 +727,11 @@ namespace InteractionFlow.Analyzers
 
                     return new DisallowReferenceInfo(targetNamespace, isDisallow, sourceShowName, targetShowName);
                 });
+            }
+
+            public SemanticModel GetSemanticModel(SyntaxTree syntaxTree)
+            {
+                return semanticModelByTree.GetOrAdd(syntaxTree, tree => compilation.GetSemanticModel(tree));
             }
         }
 

--- a/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
+++ b/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
@@ -29,13 +29,22 @@ namespace InteractionFlow.Analyzers
         public const string DependencyNodeDiagnosticId = "InteractionFlowArchitecture002";
 
         private static readonly LocalizableString Title =
-    new LocalizableResourceString(nameof(Resources.AnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+    new LocalizableResourceString(nameof(Resources.LayerDependencyAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
 
         private static readonly LocalizableString MessageFormat =
-            new LocalizableResourceString(nameof(Resources.AnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+            new LocalizableResourceString(nameof(Resources.LayerDependencyAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
 
         private static readonly LocalizableString Description =
-            new LocalizableResourceString(nameof(Resources.AnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+            new LocalizableResourceString(nameof(Resources.LayerDependencyAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+
+        private static readonly LocalizableString DependencyNodeTitle =
+            new LocalizableResourceString(nameof(Resources.DependencyNodeAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+
+        private static readonly LocalizableString DependencyNodeMessageFormat =
+            new LocalizableResourceString(nameof(Resources.DependencyNodeAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+
+        private static readonly LocalizableString DependencyNodeDescription =
+            new LocalizableResourceString(nameof(Resources.DependencyNodeAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
 
         // You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
         // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Localizing%20Analyzers.md for more on localization
@@ -47,12 +56,12 @@ namespace InteractionFlow.Analyzers
         private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
         private static readonly DiagnosticDescriptor DependencyNodeRule = new(
             DependencyNodeDiagnosticId,
-            "Incomplete dependency node declaration",
-            "{0}",
+            DependencyNodeTitle,
+            DependencyNodeMessageFormat,
             Category,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "IDependencyNode constructor dependencies must be exposed through Dependency or passed to the base dependency node.");
+            description: DependencyNodeDescription);
 
         private static readonly ImmutableDictionary<DiagnosticSeverity, DiagnosticDescriptor> RulesBySeverity =
             Enum.GetValues(typeof(DiagnosticSeverity))
@@ -357,7 +366,7 @@ namespace InteractionFlow.Analyzers
                         context,
                         analysisState,
                         location,
-                        "IDependencyNode class must be sealed or declare 'params IDependencyNode[] dependency' for derived dependency extension.");
+                        Resources.DependencyNodeMustBeSealedOrHaveParams);
                 }
 
                 foreach (var parameter in constructor.Parameters.Where(e => IsDependencyParameter(e, dependencyNode)))
@@ -372,7 +381,7 @@ namespace InteractionFlow.Analyzers
                                 context,
                                 analysisState,
                                 GetParameterDiagnosticLocation(parameter, constructor, typeLocation),
-                                $"IDependencyNode constructor parameter '{parameter.Name}' must be passed to the base IDependencyNode constructor.");
+                                string.Format(Resources.DependencyNodeParameterMustBePassedToBase, parameter.Name));
                         }
                     }
                     else if (!DependencyPropertyIncludesParameter(context, analysisState, type, dependencyNode, constructor, parameter))
@@ -381,7 +390,7 @@ namespace InteractionFlow.Analyzers
                             context,
                             analysisState,
                             GetParameterDiagnosticLocation(parameter, constructor, typeLocation),
-                            $"IDependencyNode constructor parameter '{parameter.Name}' must be included in Dependency.");
+                            string.Format(Resources.DependencyNodeParameterMustBeIncludedInDependency, parameter.Name));
                     }
                 }
             }

--- a/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
+++ b/InteractionFlow.Analyzers/InteractionFlowAnalyzersAnalyzer.cs
@@ -28,22 +28,22 @@ namespace InteractionFlow.Analyzers
         /// </summary>
         public const string DependencyNodeDiagnosticId = "InteractionFlowArchitecture002";
 
-        private static readonly LocalizableString Title =
+        private static readonly LocalizableString LayerDependencyAnalyzerTitle =
     new LocalizableResourceString(nameof(Resources.LayerDependencyAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
 
-        private static readonly LocalizableString MessageFormat =
+        private static readonly LocalizableString LayerDependencyAnalyzerMessageFormat =
             new LocalizableResourceString(nameof(Resources.LayerDependencyAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
 
-        private static readonly LocalizableString Description =
+        private static readonly LocalizableString LayerDependencyAnalyzerDescription =
             new LocalizableResourceString(nameof(Resources.LayerDependencyAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
 
-        private static readonly LocalizableString DependencyNodeTitle =
+        private static readonly LocalizableString DependencyNodeAnalyzerTitle =
             new LocalizableResourceString(nameof(Resources.DependencyNodeAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
 
-        private static readonly LocalizableString DependencyNodeMessageFormat =
+        private static readonly LocalizableString DependencyNodeAnalyzerMessageFormat =
             new LocalizableResourceString(nameof(Resources.DependencyNodeAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
 
-        private static readonly LocalizableString DependencyNodeDescription =
+        private static readonly LocalizableString DependencyNodeAnalyzerDescription =
             new LocalizableResourceString(nameof(Resources.DependencyNodeAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
 
         // You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
@@ -53,22 +53,37 @@ namespace InteractionFlow.Analyzers
         //private static readonly LocalizableString Description = "Interaction Flow Architecture - Invalid layer dependency";
         private const string Category = "Architecture";
 
-        private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
-        private static readonly DiagnosticDescriptor DependencyNodeRule = new(
-            DependencyNodeDiagnosticId,
-            DependencyNodeTitle,
-            DependencyNodeMessageFormat,
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            LayerDependencyAnalyzerTitle,
+            LayerDependencyAnalyzerMessageFormat,
             Category,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: DependencyNodeDescription);
+            description: LayerDependencyAnalyzerDescription);
+
+        private static readonly DiagnosticDescriptor DependencyNodeRule = new(
+            DependencyNodeDiagnosticId,
+            DependencyNodeAnalyzerTitle,
+            DependencyNodeAnalyzerMessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: DependencyNodeAnalyzerDescription);
 
         private static readonly ImmutableDictionary<DiagnosticSeverity, DiagnosticDescriptor> RulesBySeverity =
             Enum.GetValues(typeof(DiagnosticSeverity))
                 .Cast<DiagnosticSeverity>()
                 .ToImmutableDictionary(
                     severity => severity,
-                    severity => new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, severity, isEnabledByDefault: true, description: Description));
+                    severity => new DiagnosticDescriptor(
+                        DiagnosticId,
+                        Rule.Title,
+                        Rule.MessageFormat,
+                        Category,
+                        severity,
+                        isEnabledByDefault: true,
+                        description: Rule.Description));
 
         private static readonly ImmutableDictionary<DiagnosticSeverity, DiagnosticDescriptor> DependencyNodeRulesBySeverity =
             Enum.GetValues(typeof(DiagnosticSeverity))
@@ -805,14 +820,13 @@ namespace InteractionFlow.Analyzers
 
                 if (disallowReferenceInfo.IsDisallow)
                 {
-                    var args = new string[]
-                    {
+                    var detailMessage = string.Format(
+                        Resources.LayerDependencyDisallowedReference,
                         disallowReferenceInfo.SourceShowName,
                         disallowReferenceInfo.TargetShowName,
-                        type.Name
-                    };
+                        type.Name);
 
-                    reportDiagnostic(Diagnostic.Create(rule, location, args));
+                    reportDiagnostic(Diagnostic.Create(rule, location, detailMessage));
                     return true;
                 }
                 else

--- a/InteractionFlow.Analyzers/README.md
+++ b/InteractionFlow.Analyzers/README.md
@@ -1,0 +1,239 @@
+# InteractionFlow.Analyzers
+
+Interaction Flow の実装規則を Roslyn Analyzer として検査するプロジェクトです。
+現在は、レイヤー依存関係規則と `IDependencyNode` 宣言規則の 2 種類の診断を提供します。
+
+## 診断 ID
+
+| ID | 目的 | 既定の重大度 |
+| --- | --- | --- |
+| `InteractionFlowArchitecture001` | Interaction Flow のレイヤー間依存を検査する | Warning |
+| `InteractionFlowArchitecture002` | `IDependencyNode` 実装クラスの依存ノード宣言を検査する | Warning |
+
+実際の重大度は `.editorconfig` の `interactionflow_mode` と
+`dotnet_diagnostic.<ID>.severity` で調整できます。
+
+## Analyzer オプション
+
+`.editorconfig` から以下のキーを読み取ります。
+
+| キー | 値 | 動作 |
+| --- | --- | --- |
+| `interactionflow_enabled` | `True` / `False` | `True` の場合だけ診断します。未指定または不正値は無効扱いです。 |
+| `interactionflow_mode` | `Error` / `Warning` / `Info` / `Hidden` など | Analyzer 内部で作る診断の重大度です。不正値は `Warning` になります。 |
+| `interactionflow_allowed_roots` | カンマ区切り namespace root | 管理対象外 namespace への依存を許可する root です。`System` は常に含まれます。 |
+
+リポジトリ直下の `.editorconfig` では、現在 `interactionflow_enabled = True`、
+`interactionflow_mode = Error` が指定されています。
+
+## レイヤー依存関係規則
+
+`InteractionFlowArchitecture001` は、namespace に含まれるレイヤー名をもとに依存方向を検査します。
+対象レイヤー名は以下です。
+
+- `SystemFlows`
+- `Interactions`
+- `ExternalPorts`
+- `Externals`
+- `Builders`
+- `Entities`
+
+namespace の各セグメントを大文字小文字非依存で見て、最初に一致したレイヤー名をその型の所属レイヤーとして扱います。
+ソース側 namespace が上記レイヤーに属していない場合は、管理対象外として診断しません。
+
+### 許可される主な依存
+
+- 全レイヤーから `Entities` への依存
+- `SystemFlows` から `Interactions` への依存
+- `Interactions` から `ExternalPorts` への依存
+- `Externals` から `ExternalPorts` への依存
+- `Builders` から `SystemFlows` / `Interactions` / `ExternalPorts` / `Externals` / `Entities` への依存
+
+上記以外の管理対象レイヤー間依存は診断対象です。
+
+### 外部 namespace への依存
+
+管理対象レイヤー以外の namespace は外部依存として扱います。
+ただし、以下は診断しません。
+
+- `interactionflow_allowed_roots` に指定した namespace root とその子 namespace
+- 既定で許可される `System`
+- `Builders` からの外部依存
+- `Externals` からの外部依存
+
+外部依存の許可判定は namespace 境界で行います。
+たとえば `ThirdParty` を許可した場合、`ThirdParty.Lib` は許可されますが、`ThirdPartyX` は許可されません。
+
+### 検査する参照形状
+
+定義側と使用側の両方を検査します。
+
+定義側では、以下の型参照を検査します。
+
+- プロパティ型
+- フィールド型
+- メソッド戻り値型
+- メソッド引数型
+- 型パラメータ制約
+- 基底クラス
+- 実装 interface
+
+使用側では、以下の operation から依存先型を検査します。
+
+- オブジェクト生成
+- メソッド呼び出し
+- フィールド参照
+- プロパティ参照
+- ローカル変数宣言
+
+ジェネリック型引数、配列要素型、`Nullable<T>` の内側も再帰的に検査します。
+同じ解析対象内で同じ型を複数回見つけた場合は、重複診断を避けます。
+
+### メッセージ
+
+共通文と詳細理由を組み合わせて出力します。
+
+```text
+Invalid layer dependency: Layer '{0}' must not depend on '{1}'; referenced type: '{2}'
+```
+
+日本語リソースでは以下の形式です。
+
+```text
+レイヤー依存関係規則に違反しています: '{0}' は '{1}' に依存できません。参照型: '{2}'
+```
+
+## IDependencyNode 宣言規則
+
+`InteractionFlowArchitecture002` は、
+`InteractionFlow.Core.Entities.Architectures.IDependencyNode` を実装する class を検査します。
+interface や struct は対象外です。
+
+### 目的
+
+`IDependencyNode` 系の依存をコンストラクタで受け取る場合、その依存が `Dependency` プロパティで列挙されることを保証します。
+また、継承可能なノードでは、派生クラスが依存を追加できるように
+`params IDependencyNode[] dependency` を受け取ることを要求します。
+
+### 対象になる dependency 引数
+
+コンストラクタ引数のうち、以下を `IDependencyNode` 系の依存として扱います。
+
+- `IDependencyNode`
+- `IDependencyNode` を実装した型
+- `IDependencyNode[]`
+- `IDependencyNode` 制約を持つ型パラメータ
+
+通常コンストラクタとプライマリコンストラクタの両方を対象にします。
+
+### 非 sealed class の params 要求
+
+`IDependencyNode` 実装 class が `sealed` ではない場合、
+各通常コンストラクタまたはプライマリコンストラクタに
+`params IDependencyNode[] dependency` が必要です。
+
+`sealed` class は継承拡張の対象外なので、この params 要求は適用しません。
+
+### Dependency への包含チェック
+
+基底 class が `IDependencyNode` 実装ではない場合、
+各 `IDependencyNode` 系コンストラクタ引数が `Dependency` に含まれることを検査します。
+
+現在検出できる主な形は以下です。
+
+- `Dependency` プロパティ本体や初期化子が引数を直接参照する
+- `Dependency` が参照するフィールドまたはプロパティの宣言が引数を参照する
+- コンストラクタ内で、`Dependency` プロパティ自身または `Dependency` が参照するメンバーへ代入し、その右辺が引数を参照する
+
+例:
+
+```csharp
+public sealed class Node(IDependencyNode node) : IDependencyNode
+{
+    private readonly IDependencyNode[] dependency = [node];
+
+    public ReadOnlyMemory<IDependencyNode> Dependency => dependency;
+}
+```
+
+```csharp
+public sealed class Node : IDependencyNode
+{
+    public Node(IDependencyNode node)
+    {
+        Dependency = [node];
+    }
+
+    public ReadOnlyMemory<IDependencyNode> Dependency { get; }
+}
+```
+
+### 基底 IDependencyNode への引き渡しチェック
+
+基底 class が `IDependencyNode` 実装の場合、
+派生 class の各 `IDependencyNode` 系コンストラクタ引数は、基底コンストラクタへ渡す必要があります。
+
+通常コンストラクタの `: base(...)` と、プライマリコンストラクタの base 指定を検査します。
+
+例:
+
+```csharp
+public abstract class ChildNode(
+    IDependencyNode node,
+    params IDependencyNode[] dependency)
+    : BaseNode(node, dependency)
+{
+}
+```
+
+### メッセージ
+
+共通文と詳細理由を組み合わせて出力します。
+
+```text
+Invalid dependency node declaration: {detail}
+```
+
+詳細理由は主に以下です。
+
+- `IDependencyNode class must be sealed or declare 'params IDependencyNode[] dependency'`
+- `Parameter '{0}' must be included in Dependency`
+- `Parameter '{0}' must be passed to the base IDependencyNode constructor`
+
+日本語リソースにも同等のメッセージを定義しています。
+
+## 実装構成
+
+- `InteractionFlowAnalyzersAnalyzer.cs`
+  - Roslyn Analyzer 本体です。
+  - compilation start ごとに `CompilationAnalyzerContext` を作り、オプション、SemanticModel、レイヤー判定結果をキャッシュします。
+- `LayerNames.cs`
+  - namespace からレイヤー名を抽出し、レイヤー間または外部 namespace への依存可否を判定します。
+- `OptionValues.cs`
+  - `.editorconfig` から Analyzer オプションを読み取ります。
+- `Resources.resx` / `Resources.ja.resx`
+  - 診断タイトル、説明、共通文、詳細理由の英語・日本語リソースです。
+
+## 既知の制限
+
+- `IDependencyNode` の包含チェックは、構文上のシンボル参照を追跡する軽量な実装です。
+  複雑な制御フロー、別メソッド経由の加工、コレクションへの段階的追加などを完全には追跡しません。
+- 基底コンストラクタへの引き渡しチェックは、対象引数が base 呼び出し構文内に参照されているかを見ます。
+  引数の意味的な変換結果までは検証しません。
+- レイヤー判定は namespace 名に含まれる既定レイヤー名に依存します。
+  レイヤー名を含まない namespace は管理対象外として扱います。
+
+## 検証
+
+Analyzer 単体の確認:
+
+```powershell
+dotnet test InteractionFlow.Analyzers.Tests/InteractionFlow.Analyzers.Tests.csproj
+```
+
+ソリューション全体の確認:
+
+```powershell
+dotnet build InteractionFlow.slnx
+dotnet test InteractionFlow.slnx
+```

--- a/InteractionFlow.Analyzers/Resources.Designer.cs
+++ b/InteractionFlow.Analyzers/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace InteractionFlow.Analyzers {
         }
         
         /// <summary>
-        ///   Interaction Flow Architecture Rule - Invalid dependency node declaration に類似しているローカライズされた文字列を検索します。
+        ///   Interaction Flow Implementation Rule - Invalid dependency node declaration に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string DependencyNodeAnalyzerDescription {
             get {
@@ -70,7 +70,7 @@ namespace InteractionFlow.Analyzers {
         }
         
         /// <summary>
-        ///   {0} に類似しているローカライズされた文字列を検索します。
+        ///   Invalid dependency node declaration ({0}) に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string DependencyNodeAnalyzerMessageFormat {
             get {
@@ -86,34 +86,34 @@ namespace InteractionFlow.Analyzers {
                 return ResourceManager.GetString("DependencyNodeAnalyzerTitle", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   IDependencyNode class must be sealed or declare 'params IDependencyNode[] dependency' に類似しているローカライズされた文字列を検索します。
+        ///   IDependencyNode class must be sealed or declare &apos;params IDependencyNode[] dependency&apos; に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string DependencyNodeMustBeSealedOrHaveParams {
             get {
                 return ResourceManager.GetString("DependencyNodeMustBeSealedOrHaveParams", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Parameter '{0}' must be included in Dependency に類似しているローカライズされた文字列を検索します。
+        ///   Parameter &apos;{0}&apos; must be included in Dependency に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string DependencyNodeParameterMustBeIncludedInDependency {
             get {
                 return ResourceManager.GetString("DependencyNodeParameterMustBeIncludedInDependency", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Parameter '{0}' must be passed to the base IDependencyNode constructor に類似しているローカライズされた文字列を検索します。
+        ///   Parameter &apos;{0}&apos; must be passed to the base IDependencyNode constructor に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string DependencyNodeParameterMustBePassedToBase {
             get {
                 return ResourceManager.GetString("DependencyNodeParameterMustBePassedToBase", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Interaction Flow Architecture Rule - Invalid layer dependency に類似しているローカライズされた文字列を検索します。
         /// </summary>
@@ -122,22 +122,31 @@ namespace InteractionFlow.Analyzers {
                 return ResourceManager.GetString("LayerDependencyAnalyzerDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Layer &apos;{0}&apos; must not depend on &apos;{1}&apos; (Type = &apos;{2}&apos;) に類似しているローカライズされた文字列を検索します。
+        ///   Invalid layer dependency ({0}) に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string LayerDependencyAnalyzerMessageFormat {
             get {
                 return ResourceManager.GetString("LayerDependencyAnalyzerMessageFormat", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Invalid layer dependency に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string LayerDependencyAnalyzerTitle {
             get {
                 return ResourceManager.GetString("LayerDependencyAnalyzerTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Layer &apos;{0}&apos; must not depend on &apos;{1}&apos; (Type = &apos;{2}&apos;) に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string LayerDependencyDisallowedReference {
+            get {
+                return ResourceManager.GetString("LayerDependencyDisallowedReference", resourceCulture);
             }
         }
     }

--- a/InteractionFlow.Analyzers/Resources.Designer.cs
+++ b/InteractionFlow.Analyzers/Resources.Designer.cs
@@ -61,29 +61,83 @@ namespace InteractionFlow.Analyzers {
         }
         
         /// <summary>
-        ///   Interaction Flow Architecture Rule - Invalid layer dependency に類似しているローカライズされた文字列を検索します。
+        ///   Interaction Flow Architecture Rule - Invalid dependency node declaration に類似しているローカライズされた文字列を検索します。
         /// </summary>
-        internal static string AnalyzerDescription {
+        internal static string DependencyNodeAnalyzerDescription {
             get {
-                return ResourceManager.GetString("AnalyzerDescription", resourceCulture);
+                return ResourceManager.GetString("DependencyNodeAnalyzerDescription", resourceCulture);
             }
         }
         
+        /// <summary>
+        ///   {0} に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DependencyNodeAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("DependencyNodeAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Invalid dependency node declaration に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DependencyNodeAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("DependencyNodeAnalyzerTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   IDependencyNode class must be sealed or declare 'params IDependencyNode[] dependency' に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DependencyNodeMustBeSealedOrHaveParams {
+            get {
+                return ResourceManager.GetString("DependencyNodeMustBeSealedOrHaveParams", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Parameter '{0}' must be included in Dependency に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DependencyNodeParameterMustBeIncludedInDependency {
+            get {
+                return ResourceManager.GetString("DependencyNodeParameterMustBeIncludedInDependency", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Parameter '{0}' must be passed to the base IDependencyNode constructor に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DependencyNodeParameterMustBePassedToBase {
+            get {
+                return ResourceManager.GetString("DependencyNodeParameterMustBePassedToBase", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Interaction Flow Architecture Rule - Invalid layer dependency に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string LayerDependencyAnalyzerDescription {
+            get {
+                return ResourceManager.GetString("LayerDependencyAnalyzerDescription", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Layer &apos;{0}&apos; must not depend on &apos;{1}&apos; (Type = &apos;{2}&apos;) に類似しているローカライズされた文字列を検索します。
         /// </summary>
-        internal static string AnalyzerMessageFormat {
+        internal static string LayerDependencyAnalyzerMessageFormat {
             get {
-                return ResourceManager.GetString("AnalyzerMessageFormat", resourceCulture);
+                return ResourceManager.GetString("LayerDependencyAnalyzerMessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Invalid layer dependency に類似しているローカライズされた文字列を検索します。
         /// </summary>
-        internal static string AnalyzerTitle {
+        internal static string LayerDependencyAnalyzerTitle {
             get {
-                return ResourceManager.GetString("AnalyzerTitle", resourceCulture);
+                return ResourceManager.GetString("LayerDependencyAnalyzerTitle", resourceCulture);
             }
         }
     }

--- a/InteractionFlow.Analyzers/Resources.Designer.cs
+++ b/InteractionFlow.Analyzers/Resources.Designer.cs
@@ -70,7 +70,7 @@ namespace InteractionFlow.Analyzers {
         }
         
         /// <summary>
-        ///   Invalid dependency node declaration ({0}) に類似しているローカライズされた文字列を検索します。
+        ///   Invalid dependency node declaration: {0} に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string DependencyNodeAnalyzerMessageFormat {
             get {
@@ -124,7 +124,7 @@ namespace InteractionFlow.Analyzers {
         }
         
         /// <summary>
-        ///   Invalid layer dependency ({0}) に類似しているローカライズされた文字列を検索します。
+        ///   Invalid layer dependency: {0} に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string LayerDependencyAnalyzerMessageFormat {
             get {
@@ -142,7 +142,7 @@ namespace InteractionFlow.Analyzers {
         }
 
         /// <summary>
-        ///   Layer &apos;{0}&apos; must not depend on &apos;{1}&apos; (Type = &apos;{2}&apos;) に類似しているローカライズされた文字列を検索します。
+        ///   Layer &apos;{0}&apos; must not depend on &apos;{1}&apos;; referenced type: &apos;{2}&apos; に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string LayerDependencyDisallowedReference {
             get {

--- a/InteractionFlow.Analyzers/Resources.ja.resx
+++ b/InteractionFlow.Analyzers/Resources.ja.resx
@@ -122,7 +122,7 @@
     <comment>An optional longer localizable description of the dependency node diagnostic.</comment>
   </data>
   <data name="DependencyNodeAnalyzerMessageFormat" xml:space="preserve">
-    <value>依存ノード宣言規則に違反しています ({0})</value>
+    <value>依存ノード宣言規則に違反しています: {0}</value>
     <comment>The format-able common message the dependency node diagnostic displays.</comment>
   </data>
   <data name="DependencyNodeAnalyzerTitle" xml:space="preserve">
@@ -146,7 +146,7 @@
     <comment>An optional longer localizable description of the layer dependency diagnostic.</comment>
   </data>
   <data name="LayerDependencyAnalyzerMessageFormat" xml:space="preserve">
-    <value>レイヤー依存関係規則に違反しています ({0})</value>
+    <value>レイヤー依存関係規則に違反しています: {0}</value>
     <comment>The format-able common message the layer dependency diagnostic displays.</comment>
   </data>
   <data name="LayerDependencyAnalyzerTitle" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>The title of the layer dependency diagnostic.</comment>
   </data>
   <data name="LayerDependencyDisallowedReference" xml:space="preserve">
-    <value>'{0}' による '{1}' への依存は許可されていません (Type = '{2}')</value>
+    <value>'{0}' は '{1}' に依存できません。参照型: '{2}'</value>
     <comment>The detail message shown when a layer references a disallowed layer or external namespace.</comment>
   </data>
 </root>

--- a/InteractionFlow.Analyzers/Resources.ja.resx
+++ b/InteractionFlow.Analyzers/Resources.ja.resx
@@ -117,16 +117,40 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AnalyzerDescription" xml:space="preserve">
+  <data name="LayerDependencyAnalyzerDescription" xml:space="preserve">
     <value>Interaction Flow アーキテクチャ規則 - 依存関係規則</value>
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
-  <data name="AnalyzerMessageFormat" xml:space="preserve">
+  <data name="LayerDependencyAnalyzerMessageFormat" xml:space="preserve">
     <value>'{0}' による '{1}' への依存は、Interaction Flow アーキテクチャの依存関係規則に違反しています (Type = '{2}')</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
-  <data name="AnalyzerTitle" xml:space="preserve">
+  <data name="LayerDependencyAnalyzerTitle" xml:space="preserve">
     <value>依存関係規則の違反</value>
     <comment>The title of the diagnostic.</comment>
+  </data>
+  <data name="DependencyNodeAnalyzerDescription" xml:space="preserve">
+    <value>Interaction Flow アーキテクチャ規則 - 依存ノード宣言規則</value>
+    <comment>An optional longer localizable description of the dependency node diagnostic.</comment>
+  </data>
+  <data name="DependencyNodeAnalyzerMessageFormat" xml:space="preserve">
+    <value>{0}</value>
+    <comment>The format-able message the dependency node diagnostic displays.</comment>
+  </data>
+  <data name="DependencyNodeAnalyzerTitle" xml:space="preserve">
+    <value>依存ノード宣言規則の違反</value>
+    <comment>The title of the dependency node diagnostic.</comment>
+  </data>
+  <data name="DependencyNodeMustBeSealedOrHaveParams" xml:space="preserve">
+    <value>IDependencyNode クラスは sealed にするか 'params IDependencyNode[] dependency' を宣言する必要があります</value>
+    <comment>The message shown when a dependency node class can be inherited but cannot receive derived dependencies.</comment>
+  </data>
+  <data name="DependencyNodeParameterMustBeIncludedInDependency" xml:space="preserve">
+    <value>引数 '{0}' は Dependency に含める必要があります</value>
+    <comment>The message shown when a constructor dependency node is missing from Dependency.</comment>
+  </data>
+  <data name="DependencyNodeParameterMustBePassedToBase" xml:space="preserve">
+    <value>引数 '{0}' は基底 IDependencyNode コンストラクタへ渡す必要があります</value>
+    <comment>The message shown when a derived dependency node does not pass a constructor dependency to its base constructor.</comment>
   </data>
 </root>

--- a/InteractionFlow.Analyzers/Resources.ja.resx
+++ b/InteractionFlow.Analyzers/Resources.ja.resx
@@ -117,25 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="LayerDependencyAnalyzerDescription" xml:space="preserve">
-    <value>Interaction Flow アーキテクチャ規則 - 依存関係規則</value>
-    <comment>An optional longer localizable description of the diagnostic.</comment>
-  </data>
-  <data name="LayerDependencyAnalyzerMessageFormat" xml:space="preserve">
-    <value>'{0}' による '{1}' への依存は、Interaction Flow アーキテクチャの依存関係規則に違反しています (Type = '{2}')</value>
-    <comment>The format-able message the diagnostic displays.</comment>
-  </data>
-  <data name="LayerDependencyAnalyzerTitle" xml:space="preserve">
-    <value>依存関係規則の違反</value>
-    <comment>The title of the diagnostic.</comment>
-  </data>
   <data name="DependencyNodeAnalyzerDescription" xml:space="preserve">
-    <value>Interaction Flow アーキテクチャ規則 - 依存ノード宣言規則</value>
+    <value>Interaction Flow 実装規則 - 依存ノード宣言規則</value>
     <comment>An optional longer localizable description of the dependency node diagnostic.</comment>
   </data>
   <data name="DependencyNodeAnalyzerMessageFormat" xml:space="preserve">
-    <value>{0}</value>
-    <comment>The format-able message the dependency node diagnostic displays.</comment>
+    <value>依存ノード宣言規則に違反しています ({0})</value>
+    <comment>The format-able common message the dependency node diagnostic displays.</comment>
   </data>
   <data name="DependencyNodeAnalyzerTitle" xml:space="preserve">
     <value>依存ノード宣言規則の違反</value>
@@ -143,14 +131,30 @@
   </data>
   <data name="DependencyNodeMustBeSealedOrHaveParams" xml:space="preserve">
     <value>IDependencyNode クラスは sealed にするか 'params IDependencyNode[] dependency' を宣言する必要があります</value>
-    <comment>The message shown when a dependency node class can be inherited but cannot receive derived dependencies.</comment>
+    <comment>The detail message shown when a dependency node class can be inherited but cannot receive derived dependencies.</comment>
   </data>
   <data name="DependencyNodeParameterMustBeIncludedInDependency" xml:space="preserve">
     <value>引数 '{0}' は Dependency に含める必要があります</value>
-    <comment>The message shown when a constructor dependency node is missing from Dependency.</comment>
+    <comment>The detail message shown when a constructor dependency node is missing from Dependency.</comment>
   </data>
   <data name="DependencyNodeParameterMustBePassedToBase" xml:space="preserve">
     <value>引数 '{0}' は基底 IDependencyNode コンストラクタへ渡す必要があります</value>
-    <comment>The message shown when a derived dependency node does not pass a constructor dependency to its base constructor.</comment>
+    <comment>The detail message shown when a derived dependency node does not pass a constructor dependency to its base constructor.</comment>
+  </data>
+  <data name="LayerDependencyAnalyzerDescription" xml:space="preserve">
+    <value>Interaction Flow アーキテクチャ規則 - 依存関係規則</value>
+    <comment>An optional longer localizable description of the layer dependency diagnostic.</comment>
+  </data>
+  <data name="LayerDependencyAnalyzerMessageFormat" xml:space="preserve">
+    <value>レイヤー依存関係規則に違反しています ({0})</value>
+    <comment>The format-able common message the layer dependency diagnostic displays.</comment>
+  </data>
+  <data name="LayerDependencyAnalyzerTitle" xml:space="preserve">
+    <value>レイヤー依存関係規則の違反</value>
+    <comment>The title of the layer dependency diagnostic.</comment>
+  </data>
+  <data name="LayerDependencyDisallowedReference" xml:space="preserve">
+    <value>'{0}' による '{1}' への依存は許可されていません (Type = '{2}')</value>
+    <comment>The detail message shown when a layer references a disallowed layer or external namespace.</comment>
   </data>
 </root>

--- a/InteractionFlow.Analyzers/Resources.resx
+++ b/InteractionFlow.Analyzers/Resources.resx
@@ -122,7 +122,7 @@
     <comment>An optional longer localizable description of the layer dependency diagnostic.</comment>
   </data>
   <data name="LayerDependencyAnalyzerMessageFormat" xml:space="preserve">
-    <value>Invalid layer dependency ({0})</value>
+    <value>Invalid layer dependency: {0}</value>
     <comment>The format-able common message the layer dependency diagnostic displays.</comment>
   </data>
   <data name="LayerDependencyAnalyzerTitle" xml:space="preserve">
@@ -130,7 +130,7 @@
     <comment>The title of the layer dependency diagnostic.</comment>
   </data>
   <data name="LayerDependencyDisallowedReference" xml:space="preserve">
-    <value>Layer '{0}' must not depend on '{1}' (Type = '{2}')</value>
+    <value>Layer '{0}' must not depend on '{1}'; referenced type: '{2}'</value>
     <comment>The detail message shown when a layer references a disallowed layer or external namespace.</comment>
   </data>
   <data name="DependencyNodeAnalyzerDescription" xml:space="preserve">
@@ -138,7 +138,7 @@
     <comment>An optional longer localizable description of the dependency node diagnostic.</comment>
   </data>
   <data name="DependencyNodeAnalyzerMessageFormat" xml:space="preserve">
-    <value>Invalid dependency node declaration ({0})</value>
+    <value>Invalid dependency node declaration: {0}</value>
     <comment>The format-able common message the dependency node diagnostic displays.</comment>
   </data>
   <data name="DependencyNodeAnalyzerTitle" xml:space="preserve">

--- a/InteractionFlow.Analyzers/Resources.resx
+++ b/InteractionFlow.Analyzers/Resources.resx
@@ -117,16 +117,40 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AnalyzerDescription" xml:space="preserve">
+  <data name="LayerDependencyAnalyzerDescription" xml:space="preserve">
     <value>Interaction Flow Architecture Rule - Invalid layer dependency</value>
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
-  <data name="AnalyzerMessageFormat" xml:space="preserve">
+  <data name="LayerDependencyAnalyzerMessageFormat" xml:space="preserve">
     <value>Layer '{0}' must not depend on '{1}' (Type = '{2}')</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
-  <data name="AnalyzerTitle" xml:space="preserve">
+  <data name="LayerDependencyAnalyzerTitle" xml:space="preserve">
     <value>Invalid layer dependency</value>
     <comment>The title of the diagnostic.</comment>
+  </data>
+  <data name="DependencyNodeAnalyzerDescription" xml:space="preserve">
+    <value>Interaction Flow Architecture Rule - Invalid dependency node declaration</value>
+    <comment>An optional longer localizable description of the dependency node diagnostic.</comment>
+  </data>
+  <data name="DependencyNodeAnalyzerMessageFormat" xml:space="preserve">
+    <value>{0}</value>
+    <comment>The format-able message the dependency node diagnostic displays.</comment>
+  </data>
+  <data name="DependencyNodeAnalyzerTitle" xml:space="preserve">
+    <value>Invalid dependency node declaration</value>
+    <comment>The title of the dependency node diagnostic.</comment>
+  </data>
+  <data name="DependencyNodeMustBeSealedOrHaveParams" xml:space="preserve">
+    <value>IDependencyNode class must be sealed or declare 'params IDependencyNode[] dependency'</value>
+    <comment>The message shown when a dependency node class can be inherited but cannot receive derived dependencies.</comment>
+  </data>
+  <data name="DependencyNodeParameterMustBeIncludedInDependency" xml:space="preserve">
+    <value>Parameter '{0}' must be included in Dependency</value>
+    <comment>The message shown when a constructor dependency node is missing from Dependency.</comment>
+  </data>
+  <data name="DependencyNodeParameterMustBePassedToBase" xml:space="preserve">
+    <value>Parameter '{0}' must be passed to the base IDependencyNode constructor</value>
+    <comment>The message shown when a derived dependency node does not pass a constructor dependency to its base constructor.</comment>
   </data>
 </root>

--- a/InteractionFlow.Analyzers/Resources.resx
+++ b/InteractionFlow.Analyzers/Resources.resx
@@ -119,23 +119,27 @@
   </resheader>
   <data name="LayerDependencyAnalyzerDescription" xml:space="preserve">
     <value>Interaction Flow Architecture Rule - Invalid layer dependency</value>
-    <comment>An optional longer localizable description of the diagnostic.</comment>
+    <comment>An optional longer localizable description of the layer dependency diagnostic.</comment>
   </data>
   <data name="LayerDependencyAnalyzerMessageFormat" xml:space="preserve">
-    <value>Layer '{0}' must not depend on '{1}' (Type = '{2}')</value>
-    <comment>The format-able message the diagnostic displays.</comment>
+    <value>Invalid layer dependency ({0})</value>
+    <comment>The format-able common message the layer dependency diagnostic displays.</comment>
   </data>
   <data name="LayerDependencyAnalyzerTitle" xml:space="preserve">
     <value>Invalid layer dependency</value>
-    <comment>The title of the diagnostic.</comment>
+    <comment>The title of the layer dependency diagnostic.</comment>
+  </data>
+  <data name="LayerDependencyDisallowedReference" xml:space="preserve">
+    <value>Layer '{0}' must not depend on '{1}' (Type = '{2}')</value>
+    <comment>The detail message shown when a layer references a disallowed layer or external namespace.</comment>
   </data>
   <data name="DependencyNodeAnalyzerDescription" xml:space="preserve">
-    <value>Interaction Flow Architecture Rule - Invalid dependency node declaration</value>
+    <value>Interaction Flow Implementation Rule - Invalid dependency node declaration</value>
     <comment>An optional longer localizable description of the dependency node diagnostic.</comment>
   </data>
   <data name="DependencyNodeAnalyzerMessageFormat" xml:space="preserve">
-    <value>{0}</value>
-    <comment>The format-able message the dependency node diagnostic displays.</comment>
+    <value>Invalid dependency node declaration ({0})</value>
+    <comment>The format-able common message the dependency node diagnostic displays.</comment>
   </data>
   <data name="DependencyNodeAnalyzerTitle" xml:space="preserve">
     <value>Invalid dependency node declaration</value>
@@ -143,14 +147,14 @@
   </data>
   <data name="DependencyNodeMustBeSealedOrHaveParams" xml:space="preserve">
     <value>IDependencyNode class must be sealed or declare 'params IDependencyNode[] dependency'</value>
-    <comment>The message shown when a dependency node class can be inherited but cannot receive derived dependencies.</comment>
+    <comment>The detail message shown when a dependency node class can be inherited but cannot receive derived dependencies.</comment>
   </data>
   <data name="DependencyNodeParameterMustBeIncludedInDependency" xml:space="preserve">
     <value>Parameter '{0}' must be included in Dependency</value>
-    <comment>The message shown when a constructor dependency node is missing from Dependency.</comment>
+    <comment>The detail message shown when a constructor dependency node is missing from Dependency.</comment>
   </data>
   <data name="DependencyNodeParameterMustBePassedToBase" xml:space="preserve">
     <value>Parameter '{0}' must be passed to the base IDependencyNode constructor</value>
-    <comment>The message shown when a derived dependency node does not pass a constructor dependency to its base constructor.</comment>
+    <comment>The detail message shown when a derived dependency node does not pass a constructor dependency to its base constructor.</comment>
   </data>
 </root>

--- a/InteractionFlow.Core/Builders/SystemFlowHandler.cs
+++ b/InteractionFlow.Core/Builders/SystemFlowHandler.cs
@@ -1,3 +1,4 @@
+using InteractionFlow.Core.Entities.Architectures;
 using InteractionFlow.Core.Entities.Contexts;
 using InteractionFlow.Core.SystemFlows;
 using System;
@@ -18,6 +19,11 @@ namespace InteractionFlow.Core.Builders
     {
         private ScopeHandler? scope = scope;
         private ISystemFlow<TContext>? systemFlow = systemFlow;
+
+        /// <summary>
+        /// 保持している SystemFlow を IDependencyNode として取得します
+        /// </summary>
+        public IDependencyNode Root => systemFlow ?? throw new ObjectDisposedException(nameof(SystemFlowHandler<TContext>));
 
         /// <summary>
         /// 保持している SystemFlow を指定されたコンテキストで実行します。

--- a/InteractionFlow.Core/ExternalPorts/ReactionPorts/ICancellationPort.cs
+++ b/InteractionFlow.Core/ExternalPorts/ReactionPorts/ICancellationPort.cs
@@ -36,6 +36,11 @@ namespace InteractionFlow.Core.ExternalPorts.ReactionPorts
         /// <returns>キャンセル処理後のフロー終了結果。</returns>
         ValueTask<ReactionEnd> IExceptionPort<OperationCanceledException>.HandleExceptionAsync(IFlowContext context, OperationCanceledException exception)
         {
+            if (ThrowException)
+            {
+                throw exception;
+            }
+
             return HandleCancellationAsync(context, exception);
         }
     }

--- a/InteractionFlow.Core/Interactions/Interaction.cs
+++ b/InteractionFlow.Core/Interactions/Interaction.cs
@@ -7,16 +7,6 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Core.Interactions
 {
-    public class Test : IDependencyNode
-    {
-        public Test(IDependencyNode node1)
-        {
-            Dependency = new IDependencyNode[] { node1 };
-        }
-
-        public ReadOnlyMemory<IDependencyNode> Dependency { get; }
-    }
-
     /// <summary>
     /// <see cref="IInteraction"/> のデフォルト実装基底クラスです。
     /// </summary>

--- a/InteractionFlow.Core/Interactions/Interaction.cs
+++ b/InteractionFlow.Core/Interactions/Interaction.cs
@@ -7,6 +7,16 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Core.Interactions
 {
+    public class Test : IDependencyNode
+    {
+        public Test(IDependencyNode node1)
+        {
+            Dependency = new IDependencyNode[] { node1 };
+        }
+
+        public ReadOnlyMemory<IDependencyNode> Dependency { get; }
+    }
+
     /// <summary>
     /// <see cref="IInteraction"/> のデフォルト実装基底クラスです。
     /// </summary>

--- a/InteractionFlow.Samples.Notepad.Core/Externals/Storages/NotepadDataStorage.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Externals/Storages/NotepadDataStorage.cs
@@ -7,7 +7,7 @@ using InteractionFlow.Samples.Notepad.Core.ExternalPorts.StoragePorts.Entries;
 
 namespace InteractionFlow.Samples.Notepad.Core.Externals.Storages
 {
-    public class NotepadDataStorage : Storage<NotepadDataKey, NotepadEntry>, INotepadDataStoragePort
+    public sealed class NotepadDataStorage : Storage<NotepadDataKey, NotepadEntry>, INotepadDataStoragePort
     {
         protected override Result CanRemoveValue(NotepadDataKey key, NotepadEntry value)
         {

--- a/InteractionFlow.Samples.Notepad.Core/Externals/Storages/NotepadUserDataStorage.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Externals/Storages/NotepadUserDataStorage.cs
@@ -7,7 +7,7 @@ using InteractionFlow.Samples.Notepad.Core.ExternalPorts.StoragePorts.Entries;
 
 namespace InteractionFlow.Samples.Notepad.Core.Externals.Storages
 {
-    public class NotepadUserDataStorage : Storage<NotepadUserKey, NotepadUserEntry>, INotepadUserDataStoragePort
+    public sealed class NotepadUserDataStorage : Storage<NotepadUserKey, NotepadUserEntry>, INotepadUserDataStoragePort
     {
         protected override Result CanRemoveValue(NotepadUserKey key, NotepadUserEntry value)
         {

--- a/InteractionFlow.Samples.Notepad.Core/Externals/Storages/Persistences/NotepadDataFilePersistence.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Externals/Storages/Persistences/NotepadDataFilePersistence.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace InteractionFlow.Samples.Notepad.Core.Externals.Storages.Persistences
 {
-    public class NotepadDataFilePersistence(INotepadDataSerializerPort serializer)
+    public sealed class NotepadDataFilePersistence(INotepadDataSerializerPort serializer)
         : FilePersistence<NotepadDataKey, NotepadData>((InteractionFlow.Core.ExternalPorts.StoragePorts.SerializerPorts.ISerializerPort<Stream, NotepadData>)serializer), INotepadDataPersistencePort
     {
         public override string RootPath => Path.Combine(base.RootPath, "NotepadData");

--- a/InteractionFlow.Samples.Notepad.Core/Externals/Storages/Persistences/NotepadUserDataDirectoryPersistence.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Externals/Storages/Persistences/NotepadUserDataDirectoryPersistence.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace InteractionFlow.Samples.Notepad.Core.Externals.Storages.Persistences
 {
 
-    public class NotepadUserDataDirectoryPersistence(
+    public sealed class NotepadUserDataDirectoryPersistence(
         INotepadDataPersistencePort filePersistence,
         INotepadDataStoragePort notepadStorage)
         : DirectoryPersistence<NotepadUserKey, NotepadUserData>(filePersistence, notepadStorage), INotepadUserDataPersistencePort

--- a/InteractionFlow.Samples.Notepad.Core/Externals/Storages/Persistences/NotepadUserDataDirectoryPersistence.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Externals/Storages/Persistences/NotepadUserDataDirectoryPersistence.cs
@@ -13,7 +13,7 @@ namespace InteractionFlow.Samples.Notepad.Core.Externals.Storages.Persistences
     public class NotepadUserDataDirectoryPersistence(
         INotepadDataPersistencePort filePersistence,
         INotepadDataStoragePort notepadStorage)
-        : DirectoryPersistence<NotepadUserKey, NotepadUserData>, INotepadUserDataPersistencePort
+        : DirectoryPersistence<NotepadUserKey, NotepadUserData>(filePersistence, notepadStorage), INotepadUserDataPersistencePort
     {
         public override string RootPath => Path.Combine(base.RootPath, "NotepadData");
 

--- a/InteractionFlow.Samples.Notepad.Core/Interactions/Login.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Interactions/Login.cs
@@ -24,8 +24,17 @@ namespace InteractionFlow.Samples.Notepad.Core.Interactions
         IConsoleOperation consoleOperation,
         INotepadUserDataStoragePort notepadUserDataFiles,
         INotepadDataStoragePort notepadDataFiles,
-        INotepadUserDataPersistencePort notepadUserDataPersistence) :
-        Interaction(exceptionPort, cancellationPort, consoleReaction, consoleOperation, notepadUserDataFiles, notepadDataFiles)
+        INotepadUserDataPersistencePort notepadUserDataPersistence,
+        params IDependencyNode[] dependency) :
+        Interaction(
+            exceptionPort,
+            cancellationPort,
+            [consoleReaction,
+                consoleOperation,
+                notepadUserDataFiles,
+                notepadDataFiles,
+                notepadUserDataPersistence,
+                .. dependency])
     {
         protected IConsoleWriter ConsoleReaction => consoleReaction;
         protected IConsoleOperation ConsoleOperation => consoleOperation;

--- a/InteractionFlow.Samples.Notepad.Core/Interactions/NoteCreate.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Interactions/NoteCreate.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Notepad.Core.Interactions
 {
-    public class NoteCreate(
+    public sealed class NoteCreate(
         IExceptionPort<Exception> exceptionPort,
         ICancellationPort cancellationPort,
         IConsoleWriter consoleReaction,

--- a/InteractionFlow.Samples.Notepad.Core/Interactions/NoteCreate.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Interactions/NoteCreate.cs
@@ -25,7 +25,15 @@ namespace InteractionFlow.Samples.Notepad.Core.Interactions
         INotepadUserDataPersistencePort notepadUserDataPersistence,
         INotepadDataStoragePort notepadDataFiles,
         INotepadDataPersistencePort notepadDataPersistence) :
-        Interaction(exceptionPort, cancellationPort, consoleReaction, consoleOperation, notepadUserDataFiles)
+        Interaction(
+            exceptionPort,
+            cancellationPort,
+            consoleReaction,
+            consoleOperation,
+            notepadUserDataFiles,
+            notepadUserDataPersistence,
+            notepadDataFiles,
+            notepadDataPersistence)
     {
         protected override async Task<ReactionEnd> ExecuteCoreAsync(IFlowContext context)
         {

--- a/InteractionFlow.Samples.Notepad.Core/Interactions/NoteDelete.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Interactions/NoteDelete.cs
@@ -25,7 +25,16 @@ namespace InteractionFlow.Samples.Notepad.Core.Interactions
         INotepadUserDataPersistencePort notepadUserDataPersistence,
         INotepadDataStoragePort notepadDataFiles,
         INotepadDataPersistencePort notepadDataPersistence) :
-        Interaction(exceptionPort, cancellationPort, consoleReaction, consoleCursorPositionAccess, consoleOperation, notepadUserDataFiles, notepadDataFiles)
+        Interaction(
+            exceptionPort,
+            cancellationPort,
+            consoleReaction,
+            consoleCursorPositionAccess,
+            consoleOperation,
+            notepadUserDataFiles,
+            notepadUserDataPersistence,
+            notepadDataFiles,
+            notepadDataPersistence)
     {
         protected override async Task<ReactionEnd> ExecuteCoreAsync(IFlowContext context)
         {

--- a/InteractionFlow.Samples.Notepad.Core/Interactions/NoteDelete.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Interactions/NoteDelete.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Notepad.Core.Interactions
 {
-    public class NoteDelete(
+    public sealed class NoteDelete(
         IExceptionPort<Exception> exceptionPort,
         ICancellationPort cancellationPort,
         IConsoleWriter consoleReaction,

--- a/InteractionFlow.Samples.Notepad.Core/Interactions/NoteEdit.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Interactions/NoteEdit.cs
@@ -29,7 +29,16 @@ namespace InteractionFlow.Samples.Notepad.Core.Interactions
         INotepadDataStoragePort notepadDataFiles,
         INotepadUserDataPersistencePort notepadUserDataPersistence,
         INotepadDataPersistencePort notepadDataPersistence) :
-        Interaction(exceptionPort, cancellationPort, consoleReaction, consoleCursorPositionAccess, consoleOperation, notepadUserDataFiles, notepadDataFiles)
+        Interaction(
+            exceptionPort,
+            cancellationPort,
+            consoleReaction,
+            consoleCursorPositionAccess,
+            consoleOperation,
+            notepadUserDataFiles,
+            notepadDataFiles,
+            notepadUserDataPersistence,
+            notepadDataPersistence)
     {
         private class ConsoleTextWriter(IConsoleCursorPositionAccess consoleCursorPositionAccess, IConsoleWriter consoleReaction, IConsoleOperation consoleOperation)
         {

--- a/InteractionFlow.Samples.Notepad.Core/Interactions/NoteEdit.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Interactions/NoteEdit.cs
@@ -19,7 +19,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Notepad.Core.Interactions
 {
-    public class NoteEdit(
+    public sealed class NoteEdit(
         IExceptionPort<Exception> exceptionPort,
         ICancellationPort cancellationPort,
         IConsoleWriter consoleReaction,

--- a/InteractionFlow.Samples.Notepad.Core/Interactions/NoteListView.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Interactions/NoteListView.cs
@@ -22,7 +22,14 @@ namespace InteractionFlow.Samples.Notepad.Core.Interactions
         INotepadDataStoragePort notepadDataFiles,
         INotepadUserDataPersistencePort notepadUserDataPersistence,
         INotepadDataPersistencePort notepadDataPersistence) :
-        Interaction(exceptionPort, cancellationPort, consoleReaction, notepadUserDataFiles, notepadDataFiles)
+        Interaction(
+            exceptionPort,
+            cancellationPort,
+            consoleReaction,
+            notepadUserDataFiles,
+            notepadDataFiles,
+            notepadUserDataPersistence,
+            notepadDataPersistence)
     {
         protected override async Task<ReactionEnd> ExecuteCoreAsync(IFlowContext context)
         {

--- a/InteractionFlow.Samples.Notepad.Core/Interactions/NoteListView.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Interactions/NoteListView.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 namespace InteractionFlow.Samples.Notepad.Core.Interactions
 {
 
-    public class NoteListView(
+    public sealed class NoteListView(
         IExceptionPort<Exception> exceptionPort,
         ICancellationPort cancellationPort,
         IConsoleWriter consoleReaction,

--- a/InteractionFlow.Samples.Notepad.Core/Interactions/SelectUserAction.cs
+++ b/InteractionFlow.Samples.Notepad.Core/Interactions/SelectUserAction.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Notepad.Core.Interactions
 {
-    public class SelectUserAction(
+    public sealed class SelectUserAction(
         IExceptionPort<Exception> exceptionPort,
         ICancellationPort cancellationPort,
         IConsoleWriter consoleReaction,

--- a/InteractionFlow.Samples.Notepad.Core/SystemFlows/MainLoop.cs
+++ b/InteractionFlow.Samples.Notepad.Core/SystemFlows/MainLoop.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Notepad.Core.SystemFlows
 {
-    public class MainLoop(
+    public sealed class MainLoop(
         Login login,
         NoteListView noteListView,
         SelectUserAction selectUserAction,

--- a/InteractionFlow.Samples.Notepad.Secure/Externals/Storages/CurrentUserFilesStorage.cs
+++ b/InteractionFlow.Samples.Notepad.Secure/Externals/Storages/CurrentUserFilesStorage.cs
@@ -7,7 +7,7 @@ using InteractionFlow.Samples.Notepad.Secure.ExternalPorts.StoragePorts;
 
 namespace InteractionFlow.Samples.Notepad.Secure.Externals.Storages
 {
-    public class CurrentUserFilesStorage : Storage<NotepadUserKey, PersistentEntry<NotepadUserKey, UserSecureData>>, ICurrentUserStoragePort
+    public sealed class CurrentUserFilesStorage : Storage<NotepadUserKey, PersistentEntry<NotepadUserKey, UserSecureData>>, ICurrentUserStoragePort
     {
         public NotepadUserKey LastUser { get; private set; }
 

--- a/InteractionFlow.Samples.Notepad.Secure/Externals/Storages/Persistences/UserSecureDataFilePersistence.cs
+++ b/InteractionFlow.Samples.Notepad.Secure/Externals/Storages/Persistences/UserSecureDataFilePersistence.cs
@@ -9,7 +9,7 @@ using System.IO;
 namespace InteractionFlow.Samples.Notepad.Secure.Externals.Storages.Persistences
 {
 
-    public class UserSecureDataFilePersistence(IUserSecureDataSerializerPort serializer)
+    public sealed class UserSecureDataFilePersistence(IUserSecureDataSerializerPort serializer)
         : FilePersistence<NotepadUserKey, UserSecureData>((InteractionFlow.Core.ExternalPorts.StoragePorts.SerializerPorts.ISerializerPort<Stream, UserSecureData>)serializer), IUserSecureDataPersistencePort
     {
         public override string Extention => ".user";

--- a/InteractionFlow.Samples.Notepad.Secure/Externals/Storages/Serializers/NotepadDataSecureSerializer.cs
+++ b/InteractionFlow.Samples.Notepad.Secure/Externals/Storages/Serializers/NotepadDataSecureSerializer.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Notepad.Secure.Externals.Storages.Serializers
 {
-    internal class NotepadDataSecureSerializer(ISecureManagerPort secureManager, ICurrentUserStoragePort currentUserStorage)
+    internal sealed class NotepadDataSecureSerializer(ISecureManagerPort secureManager, ICurrentUserStoragePort currentUserStorage)
         : StreamSerializer<NotepadData>(currentUserStorage), INotepadDataSerializerPort
     {
         private SecretBuffer GetUserKey()

--- a/InteractionFlow.Samples.Notepad.Secure/Externals/Storages/Serializers/NotepadDataSecureSerializer.cs
+++ b/InteractionFlow.Samples.Notepad.Secure/Externals/Storages/Serializers/NotepadDataSecureSerializer.cs
@@ -12,7 +12,8 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Notepad.Secure.Externals.Storages.Serializers
 {
-    internal class NotepadDataSecureSerializer(ISecureManagerPort secureManager, ICurrentUserStoragePort currentUserStorage) : StreamSerializer<NotepadData>, INotepadDataSerializerPort
+    internal class NotepadDataSecureSerializer(ISecureManagerPort secureManager, ICurrentUserStoragePort currentUserStorage)
+        : StreamSerializer<NotepadData>(currentUserStorage), INotepadDataSerializerPort
     {
         private SecretBuffer GetUserKey()
         {

--- a/InteractionFlow.Samples.Notepad.Secure/Externals/Storages/Serializers/UserSecureDataSerializer.cs
+++ b/InteractionFlow.Samples.Notepad.Secure/Externals/Storages/Serializers/UserSecureDataSerializer.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Notepad.Secure.Externals.Storages.Serializers
 {
-    public class UserSecureDataSerializer : StreamSerializer<UserSecureData>, IUserSecureDataSerializerPort
+    public sealed class UserSecureDataSerializer : StreamSerializer<UserSecureData>, IUserSecureDataSerializerPort
     {
         public override async Task<Result<UserSecureData>> Deserialize(Result<Stream> inputData, Result<UserSecureData> refValue)
         {

--- a/InteractionFlow.Samples.Notepad.Secure/Interactions/EnterPassword.cs
+++ b/InteractionFlow.Samples.Notepad.Secure/Interactions/EnterPassword.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 namespace InteractionFlow.Samples.Notepad.Secure.Interactions
 
 {
-    internal class EnterPassword(
+    internal sealed class EnterPassword(
             IExceptionPort<Exception> exceptionPort,
             ICancellationPort cancellationPort,
             IConsoleWriter consoleReaction,

--- a/InteractionFlow.Samples.Notepad.Secure/Interactions/LoginSecure.cs
+++ b/InteractionFlow.Samples.Notepad.Secure/Interactions/LoginSecure.cs
@@ -19,7 +19,7 @@ using System.Threading.Tasks;
 namespace InteractionFlow.Samples.Notepad.Secure.Interactions
 {
 
-    internal class LoginSecure(
+    internal sealed class LoginSecure(
             IExceptionPort<Exception> exceptionPort,
             ICancellationPort cancellationPort,
             IConsoleWriter consoleReaction,

--- a/InteractionFlow.Samples.Notepad.Secure/Interactions/LoginSecure.cs
+++ b/InteractionFlow.Samples.Notepad.Secure/Interactions/LoginSecure.cs
@@ -40,7 +40,11 @@ namespace InteractionFlow.Samples.Notepad.Secure.Interactions
             consoleOperation,
             notepadUserDataFiles,
             notepadDataFiles,
-            notepadUserDataPersistence)
+            notepadUserDataPersistence,
+            currentUserStorage,
+            userSecureDataPersistence,
+            notepadDataPersistence,
+            enterPassword)
     {
         private const string ExceptionDataKey_CurrentUserEntry = "currentUserEntry";
 

--- a/InteractionFlow.Samples.Notepad.Secure/Program.cs
+++ b/InteractionFlow.Samples.Notepad.Secure/Program.cs
@@ -55,6 +55,9 @@ namespace InteractionFlow.Samples.Notepad.Secure
 
             var mainLoop = scope.BuildSystemFlow<MainLoop, NotepadContext>();
 
+            var treeText = DependencyTreeView.GetDependencyTreeText(mainLoop.Root);
+            Console.WriteLine(treeText);
+
             var context = new NotepadContext(NotepadUserObject.Public);
 
             var end = await mainLoop.ExecuteAsync(context);

--- a/InteractionFlow.Samples.Notepad/Externals/Serializers/NotepadDataSimpleSerializer.cs
+++ b/InteractionFlow.Samples.Notepad/Externals/Serializers/NotepadDataSimpleSerializer.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Notepad.Externals.Serializers
 {
-    internal class NotepadDataSimpleSerializer : TextSerializer<NotepadData>, INotepadDataSerializerPort
+    internal sealed class NotepadDataSimpleSerializer : TextSerializer<NotepadData>, INotepadDataSerializerPort
     {
         public override Task<Result<NotepadData>> Deserialize(Result<string> inputText, Result<NotepadData> refValue)
         {

--- a/InteractionFlow.Samples.Notepad/Program.cs
+++ b/InteractionFlow.Samples.Notepad/Program.cs
@@ -38,6 +38,9 @@ namespace InteractionFlow.Samples.Notepad
 
             var mainLoop = scope.BuildSystemFlow<MainLoop, NotepadContext>();
 
+            var treeText = DependencyTreeView.GetDependencyTreeText(mainLoop.Root);
+            Console.WriteLine(treeText);
+
             var context = new NotepadContext(NotepadUserObject.Public);
 
             var end = await mainLoop.ExecuteAsync(context);

--- a/InteractionFlow.Samples.Parrot/Externals/Storages/LastSelectMemory.cs
+++ b/InteractionFlow.Samples.Parrot/Externals/Storages/LastSelectMemory.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace InteractionFlow.Samples.Parrot.Externals.Storages
 {
-    internal class LastSelectMemory : Storage<bool, RefEntry<SampleID>>, ILastSelectMemory
+    internal sealed class LastSelectMemory : Storage<bool, RefEntry<SampleID>>, ILastSelectMemory
     {
         public override Result<bool> GetKey(IFlowContext context)
         {

--- a/InteractionFlow.Samples.Parrot/Interactions/ConsoleSetup.cs
+++ b/InteractionFlow.Samples.Parrot/Interactions/ConsoleSetup.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Parrot.Interactions
 {
-    internal class ConsoleSetup(
+    internal sealed class ConsoleSetup(
         IExceptionPort<Exception> exception,
         ICancellationPort cancellation,
         ICancellationWithConsole cancellationWithConsole,

--- a/InteractionFlow.Samples.Parrot/Interactions/ConsoleSetup.cs
+++ b/InteractionFlow.Samples.Parrot/Interactions/ConsoleSetup.cs
@@ -15,7 +15,7 @@ namespace InteractionFlow.Samples.Parrot.Interactions
         ICancellationWithConsole cancellationWithConsole,
         IConsoleColorAccess consoleColorAccess,
         IConsoleWriter console)
-        : Interaction(exception, cancellation, cancellationWithConsole, console)
+        : Interaction(exception, cancellation, cancellationWithConsole, consoleColorAccess, console)
     {
         protected override async Task<ReactionEnd> ExecuteCoreAsync(IFlowContext context)
         {

--- a/InteractionFlow.Samples.Parrot/Interactions/ListSamples.cs
+++ b/InteractionFlow.Samples.Parrot/Interactions/ListSamples.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Parrot.Interactions
 {
-    internal class ListSamples(
+    internal sealed class ListSamples(
         IExceptionPort<Exception> exception,
         ICancellationPort cancellation,
         IConsoleWriter console)

--- a/InteractionFlow.Samples.Parrot/Interactions/Parrot.cs
+++ b/InteractionFlow.Samples.Parrot/Interactions/Parrot.cs
@@ -15,7 +15,7 @@ namespace InteractionFlow.Samples.Parrot.Interactions
 {
 
 
-    internal class Parrot(
+    internal sealed class Parrot(
         IExceptionPort<Exception> exception,
         ICancellationPort cancellation,
         IConsoleOperation operation,

--- a/InteractionFlow.Samples.Parrot/Interactions/RunSample.cs
+++ b/InteractionFlow.Samples.Parrot/Interactions/RunSample.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Parrot.Interactions
 {
-    internal class RunSample(
+    internal sealed class RunSample(
         IExceptionPort<Exception> exception,
         ICancellationPort cancellation,
         IConsoleOperation operation,

--- a/InteractionFlow.Samples.Parrot/Interactions/SelectSample.cs
+++ b/InteractionFlow.Samples.Parrot/Interactions/SelectSample.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Parrot.Interactions
 {
-    internal class SelectSample(
+    internal sealed class SelectSample(
         IExceptionPort<Exception> exception,
         ICancellationPort cancellation,
         IConsoleWriter reaction,

--- a/InteractionFlow.Samples.Parrot/Program.cs
+++ b/InteractionFlow.Samples.Parrot/Program.cs
@@ -7,6 +7,7 @@ using InteractionFlow.Samples.Parrot.Interactions;
 using InteractionFlow.Samples.Parrot.SystemFlows;
 using InteractionFlow.Standard.Builders;
 using InteractionFlow.Standard.Interactions;
+using System;
 using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Parrot
@@ -44,6 +45,9 @@ namespace InteractionFlow.Samples.Parrot
             }
 
             using var selectAndRunSample = globalScope.BuildSystemFlow<SelectAndRunSample, IFlowContext>();
+
+            var treeText = DependencyTreeView.GetDependencyTreeText(selectAndRunSample.Root);
+            Console.WriteLine(treeText);
 
             while (true)
             {

--- a/InteractionFlow.Samples.Parrot/SystemFlows/InitializeApplication.cs
+++ b/InteractionFlow.Samples.Parrot/SystemFlows/InitializeApplication.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace InteractionFlow.Samples.Parrot.SystemFlows
 {
 
-    internal class InitializeApplication(
+    internal sealed class InitializeApplication(
         ConsoleWriting writing,
         ConsoleSetup assigneCancelKey)
         : SystemFlow<IFlowContext>(writing, assigneCancelKey)

--- a/InteractionFlow.Samples.Parrot/SystemFlows/SelectAndRunSample.cs
+++ b/InteractionFlow.Samples.Parrot/SystemFlows/SelectAndRunSample.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace InteractionFlow.Samples.Parrot.SystemFlows
 {
-    internal class SelectAndRunSample(
+    internal sealed class SelectAndRunSample(
         ConsoleWriting writing,
         ListSamples listSamples,
         SelectSample selectSample,

--- a/InteractionFlow.Standard/Builders/DependencyTreeView.cs
+++ b/InteractionFlow.Standard/Builders/DependencyTreeView.cs
@@ -1,0 +1,34 @@
+using InteractionFlow.Core.Entities.Architectures;
+using System.Text;
+
+namespace InteractionFlow.Standard.Builders
+{
+    /// <summary>
+    /// <see cref="IDependencyNode"/> 依存ツリーの可視化を提供するクラスです。
+    /// </summary>
+    public static class DependencyTreeView
+    {
+        /// <summary>
+        /// <paramref name="root"/> を根とした依存ツリーを可視化するインデント付き文字列を構築します。
+        /// </summary>
+        /// <param name="root">依存ツリーの根となる <see cref="IDependencyNode"/></param>
+        /// <returns>依存ツリーを可視化するインデント付き文字列</returns>
+        public static string GetDependencyTreeText(IDependencyNode root)
+        {
+            var builder = new StringBuilder();
+            AppendDependencyTreeText(builder, root, 0);
+            return builder.ToString();
+        }
+
+        private static void AppendDependencyTreeText(StringBuilder builder, IDependencyNode node, int depth)
+        {
+            builder.Append(' ', depth * 4);
+            builder.AppendLine(node.ToString());
+
+            foreach (var dependency in node.Dependency.Span)
+            {
+                AppendDependencyTreeText(builder, dependency, depth + 1);
+            }
+        }
+    }
+}

--- a/InteractionFlow.Standard/Builders/DependencyTreeView.cs
+++ b/InteractionFlow.Standard/Builders/DependencyTreeView.cs
@@ -9,10 +9,10 @@ namespace InteractionFlow.Standard.Builders
     public static class DependencyTreeView
     {
         /// <summary>
-        /// <paramref name="root"/> を根とした依存ツリーを可視化するインデント付き文字列を構築します。
+        /// <paramref name="root"/> を根とした依存ツリーを可視化する Markdown ツリー文字列を構築します。
         /// </summary>
         /// <param name="root">依存ツリーの根となる <see cref="IDependencyNode"/></param>
-        /// <returns>依存ツリーを可視化するインデント付き文字列</returns>
+        /// <returns>依存ツリーを可視化する Markdown ツリー文字列</returns>
         public static string GetDependencyTreeText(IDependencyNode root)
         {
             var builder = new StringBuilder();
@@ -22,7 +22,8 @@ namespace InteractionFlow.Standard.Builders
 
         private static void AppendDependencyTreeText(StringBuilder builder, IDependencyNode node, int depth)
         {
-            builder.Append(' ', depth * 4);
+            builder.Append(' ', depth * 2);
+            builder.Append("- ");
             builder.AppendLine(node.ToString());
 
             foreach (var dependency in node.Dependency.Span)

--- a/InteractionFlow.Standard/Builders/ScopeServices.cs
+++ b/InteractionFlow.Standard/Builders/ScopeServices.cs
@@ -1,4 +1,5 @@
 using InteractionFlow.Core.Builders;
+using InteractionFlow.Core.Entities.Architectures;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 
@@ -9,6 +10,14 @@ namespace InteractionFlow.Standard.Builders
     /// </summary>
     public abstract class ScopeServices : IScopeServices
     {
+        /// <summary>
+        /// 自信を初期化して、params IDependencyNode[] の自動解決を登録します
+        /// </summary>
+        protected ScopeServices()
+        {
+            Services.AddSingleton<IDependencyNode[]>([]);
+        }
+
         /// <summary>
         /// スコープ生成前のサービス登録コレクションを取得または設定します。
         /// </summary>

--- a/InteractionFlow.Standard/Externals/Operations/ConsoleOperation.cs
+++ b/InteractionFlow.Standard/Externals/Operations/ConsoleOperation.cs
@@ -1,3 +1,4 @@
+using InteractionFlow.Core.Entities.Architectures;
 using InteractionFlow.Core.Entities.Contexts;
 using InteractionFlow.Core.Externals.Operations;
 using InteractionFlow.Standard.Entities.Consoles;
@@ -17,7 +18,8 @@ namespace InteractionFlow.Standard.Externals.Operations
         /// <summary>
         /// 既定のコンソール入力状態でインスタンスを作成します。
         /// </summary>
-        public ConsoleOperation() : base()
+        /// <param name="dependency">この Operation が依存するフローノード。</param>
+        public ConsoleOperation(params IDependencyNode[] dependency) : base(dependency)
         {
             ResetFields();
 
@@ -175,7 +177,8 @@ namespace InteractionFlow.Standard.Externals.Operations
             /// <summary>
             /// 既定のダミー入力状態でインスタンスを作成します。
             /// </summary>
-            public Dummy() : base()
+            /// <param name="dependency">この Operation が依存するフローノード。</param>
+            public Dummy(params IDependencyNode[] dependency) : base(dependency)
             {
                 ResetFields();
 

--- a/InteractionFlow.Standard/Externals/Reactions/ConsoleCancellationHandling.cs
+++ b/InteractionFlow.Standard/Externals/Reactions/ConsoleCancellationHandling.cs
@@ -1,4 +1,5 @@
 using InteractionFlow.Core.Entities;
+using InteractionFlow.Core.Entities.Architectures;
 using InteractionFlow.Core.Entities.Contexts;
 using InteractionFlow.Core.Externals.Reactions;
 using InteractionFlow.Standard.Entities.Consoles;
@@ -17,7 +18,8 @@ namespace InteractionFlow.Standard.Externals.Reactions
         /// <summary>
         /// 既定のキャンセル表示状態でインスタンスを作成します。
         /// </summary>
-        public ConsoleCancellationHandling() : base()
+        /// <param name="dependency">この Reaction が依存するフローノード。</param>
+        public ConsoleCancellationHandling(params IDependencyNode[] dependency) : base(dependency)
         {
             ResetFields();
 

--- a/InteractionFlow.Standard/Externals/Reactions/ConsoleExceptionHandling.cs
+++ b/InteractionFlow.Standard/Externals/Reactions/ConsoleExceptionHandling.cs
@@ -1,3 +1,4 @@
+using InteractionFlow.Core.Entities.Architectures;
 using InteractionFlow.Core.Entities.Contexts;
 using InteractionFlow.Core.Externals.Reactions;
 using InteractionFlow.Standard.Entities.Consoles;
@@ -16,7 +17,8 @@ namespace InteractionFlow.Standard.Externals.Reactions
         /// <summary>
         /// 既定の例外表示状態でインスタンスを作成します。
         /// </summary>
-        public ConsoleExceptionHandling()
+        /// <param name="dependency">この Reaction が依存するフローノード。</param>
+        public ConsoleExceptionHandling(params IDependencyNode[] dependency) : base(dependency)
         {
             ResetFields();
 

--- a/InteractionFlow.Standard/Externals/Reactions/ConsoleWriter.cs
+++ b/InteractionFlow.Standard/Externals/Reactions/ConsoleWriter.cs
@@ -1,3 +1,4 @@
+using InteractionFlow.Core.Entities.Architectures;
 using InteractionFlow.Core.Entities.Contexts;
 using InteractionFlow.Core.Externals.Reactions;
 using InteractionFlow.Standard.Entities.Consoles;
@@ -16,7 +17,8 @@ namespace InteractionFlow.Standard.Externals.Reactions
         /// <summary>
         /// 既定のコンソール出力状態でインスタンスを作成します。
         /// </summary>
-        public ConsoleWriter() : base()
+        /// <param name="dependency">この Reaction が依存するフローノード。</param>
+        public ConsoleWriter(params IDependencyNode[] dependency) : base(dependency)
         {
             ResetFields();
 

--- a/InteractionFlow.Standard/Externals/SilentExternals/CancellationWithConsole.cs
+++ b/InteractionFlow.Standard/Externals/SilentExternals/CancellationWithConsole.cs
@@ -1,3 +1,4 @@
+using InteractionFlow.Core.Entities.Architectures;
 using InteractionFlow.Core.Entities.Contexts;
 using InteractionFlow.Core.Externals.SilentExternals;
 using InteractionFlow.Standard.ExternalPorts.SilentExternalPorts;
@@ -12,6 +13,14 @@ namespace InteractionFlow.Standard.Externals.SilentExternals
     public class CancellationWithConsole : SilentExternal, ICancellationWithConsole
     {
         ConsoleCancelEventHandler? cancelKeyPress;
+
+        /// <summary>
+        /// 依存ノードを保持するインスタンスを作成します。
+        /// </summary>
+        /// <param name="dependency">この SilentExternal が依存するフローノード。</param>
+        public CancellationWithConsole(params IDependencyNode[] dependency) : base(dependency)
+        {
+        }
 
         /// <summary>
         /// 指定されたコンテキストに対して Ctrl+C キャンセル連携を設定します。

--- a/InteractionFlow.Standard/Externals/SilentExternals/ConsoleColorAccess.cs
+++ b/InteractionFlow.Standard/Externals/SilentExternals/ConsoleColorAccess.cs
@@ -1,3 +1,4 @@
+using InteractionFlow.Core.Entities.Architectures;
 using InteractionFlow.Core.Entities.Contexts;
 using InteractionFlow.Standard.ExternalPorts.SilentExternalPorts;
 using System;
@@ -10,6 +11,14 @@ namespace InteractionFlow.Standard.Externals.SilentExternals
     /// </summary>
     public class ConsoleColorAccess : SilentRequest<(ConsoleColor foreground, ConsoleColor background), (ConsoleColor? foreground, ConsoleColor? background)>, IConsoleColorAccess
     {
+        /// <summary>
+        /// 依存ノードを保持するインスタンスを作成します。
+        /// </summary>
+        /// <param name="dependency">この SilentExternal が依存するフローノード。</param>
+        public ConsoleColorAccess(params IDependencyNode[] dependency) : base(dependency)
+        {
+        }
+
         /// <summary>
         /// 現在の前景色を取得または設定します。
         /// </summary>

--- a/InteractionFlow.Standard/Externals/SilentExternals/ConsoleCursorPositionAccess.cs
+++ b/InteractionFlow.Standard/Externals/SilentExternals/ConsoleCursorPositionAccess.cs
@@ -1,3 +1,4 @@
+using InteractionFlow.Core.Entities.Architectures;
 using InteractionFlow.Core.Entities.Contexts;
 using InteractionFlow.Standard.Entities.Consoles;
 using InteractionFlow.Standard.ExternalPorts.SilentExternalPorts;
@@ -12,6 +13,14 @@ namespace InteractionFlow.Standard.Externals.SilentExternals
     /// </summary>
     public class ConsoleCursorPositionAccess : SilentRequest<ConsoleCursorPosition, ConsoleCursorPosition>, IConsoleCursorPositionAccess
     {
+        /// <summary>
+        /// 依存ノードを保持するインスタンスを作成します。
+        /// </summary>
+        /// <param name="dependency">この SilentExternal が依存するフローノード。</param>
+        public ConsoleCursorPositionAccess(params IDependencyNode[] dependency) : base(dependency)
+        {
+        }
+
         /// <summary>
         /// 現在のカーソル位置を取得または設定します。
         /// </summary>

--- a/InteractionFlow.Standard/Externals/Storages/Persistences/DirectoryPersistence.cs
+++ b/InteractionFlow.Standard/Externals/Storages/Persistences/DirectoryPersistence.cs
@@ -20,16 +20,20 @@ namespace InteractionFlow.Standard.Externals.Storages.Persistences
     /// <typeparam name="TValue">保存または読み込みする値の型。</typeparam>
     public abstract class DirectoryPersistence<TDirectoryId, TValue> : IDirectoryPersistencePort<TDirectoryId, TValue>
     {
+        private readonly IDependencyNode[] dependency;
+
         /// <summary>
         /// この Persistence が依存する補助ノードを取得します。
         /// </summary>
-        public virtual ReadOnlyMemory<IDependencyNode> Dependency => ReadOnlyMemory<IDependencyNode>.Empty;
+        public virtual ReadOnlyMemory<IDependencyNode> Dependency => dependency;
 
         /// <summary>
         /// ルートパス配下の保存先を使用できるように初期化します。
         /// </summary>
-        public DirectoryPersistence()
+        /// <param name="dependency">この Persistence が依存する補助ノード。</param>
+        public DirectoryPersistence(params IDependencyNode[] dependency)
         {
+            this.dependency = dependency;
             CreateDirectories(Environment.CurrentDirectory, RootPath);
         }
 

--- a/InteractionFlow.Standard/Externals/Storages/Persistences/FilePersistence.cs
+++ b/InteractionFlow.Standard/Externals/Storages/Persistences/FilePersistence.cs
@@ -20,14 +20,18 @@ namespace InteractionFlow.Standard.Externals.Storages.Persistences
     /// <typeparam name="TFileId">ファイルを識別する ID の型。</typeparam>
     /// <typeparam name="TValue">保存または読み込みする値の型。</typeparam>
     /// <param name="serializer">値とストリームの変換に使用する Serializer。</param>
-    public abstract class FilePersistence<TFileId, TValue>(ISerializerPort<Stream, TValue> serializer) : IFilePersistencePort<TFileId, TValue>
+    /// <param name="dependency">この Persistence が依存する補助ノード。</param>
+    public abstract class FilePersistence<TFileId, TValue>(
+        ISerializerPort<Stream, TValue> serializer,
+        params IDependencyNode[] dependency)
+        : IFilePersistencePort<TFileId, TValue>
     {
-        private readonly IDependencyNode[] dependency = [serializer];
+        private readonly IDependencyNode[] dependencies = [serializer, .. dependency];
 
         /// <summary>
         /// この Persistence が依存する補助ノードを取得します。
         /// </summary>
-        public virtual ReadOnlyMemory<IDependencyNode> Dependency => dependency;
+        public virtual ReadOnlyMemory<IDependencyNode> Dependency => dependencies;
 
         /// <summary>
         /// 保存先のルートパスを取得します。

--- a/InteractionFlow.Standard/Externals/Storages/Serializers/StreamSerializer.cs
+++ b/InteractionFlow.Standard/Externals/Storages/Serializers/StreamSerializer.cs
@@ -11,12 +11,13 @@ namespace InteractionFlow.Standard.Externals.Storages.Serializers
     /// <see cref="Stream"/> と値を相互変換する Serializer の基底クラスです。
     /// </summary>
     /// <typeparam name="TValue">変換対象の値の型。</typeparam>
-    public abstract class StreamSerializer<TValue> : ISerializerPort<Stream, TValue>
+    /// <param name="dependency">この Serializer が依存する補助ノード。</param>
+    public abstract class StreamSerializer<TValue>(params IDependencyNode[] dependency) : ISerializerPort<Stream, TValue>
     {
         /// <summary>
         /// この Serializer が依存する補助ノードを取得します。
         /// </summary>
-        public virtual ReadOnlyMemory<IDependencyNode> Dependency => ReadOnlyMemory<IDependencyNode>.Empty;
+        public virtual ReadOnlyMemory<IDependencyNode> Dependency => dependency;
 
         /// <summary>
         /// ストリームから値へ変換します。

--- a/InteractionFlow.Standard/Externals/Storages/Serializers/TextSerializer.cs
+++ b/InteractionFlow.Standard/Externals/Storages/Serializers/TextSerializer.cs
@@ -1,4 +1,5 @@
 using InteractionFlow.Core.Entities;
+using InteractionFlow.Core.Entities.Architectures;
 using InteractionFlow.Core.ExternalPorts.StoragePorts.SerializerPorts;
 using System;
 using System.IO;
@@ -11,7 +12,9 @@ namespace InteractionFlow.Standard.Externals.Storages.Serializers
     /// 文字列形式の変換を基準に、ストリームとの相互変換も提供する Serializer 基底クラスです。
     /// </summary>
     /// <typeparam name="TValue">変換対象の値の型。</typeparam>
-    public abstract class TextSerializer<TValue> : StreamSerializer<TValue>, ISerializerPort<string, TValue>
+    /// <param name="dependency">この Serializer が依存する補助ノード。</param>
+    public abstract class TextSerializer<TValue>(params IDependencyNode[] dependency)
+        : StreamSerializer<TValue>(dependency), ISerializerPort<string, TValue>
     {
         /// <summary>
         /// 値を文字列へ変換します。

--- a/InteractionFlow.Standard/Interactions/ConsoleWriting.cs
+++ b/InteractionFlow.Standard/Interactions/ConsoleWriting.cs
@@ -14,11 +14,13 @@ namespace InteractionFlow.Standard.Interactions
     /// <param name="exception">通常の例外をフロー終了時の反応へ変換するポート。</param>
     /// <param name="cancellation">キャンセルをフロー終了時の反応へ変換するポート。</param>
     /// <param name="consoleWrite">コンソール出力に使用する Reaction ポート。</param>
+    /// <param name="dependency">この Interaction が明示的に依存するフローノード。</param>
     public class ConsoleWriting(
         IExceptionPort<Exception> exception,
         ICancellationPort cancellation,
-        IConsoleWriter consoleWrite)
-        : InteractionOptionalArg<(ConsoleOutput?, ConsoleState?)>(exception, cancellation, consoleWrite)
+        IConsoleWriter consoleWrite,
+        params IDependencyNode[] dependency)
+        : InteractionOptionalArg<(ConsoleOutput?, ConsoleState?)>(exception, cancellation, [consoleWrite, .. dependency])
     {
         /// <summary>
         /// 出力内容と出力状態の既定オプションを取得します。


### PR DESCRIPTION
## 概要

`IDependencyNode` ベースの依存宣言規則を Analyzer に追加し、
既存のレイヤー依存 Analyzer と同じ枠組みで診断できるようにしました。

あわせて、新しい規則に合わせて `.Standard` / `.Samples.*` 側の `IDependencyNode` 実装を追従し、
依存ツリーの可視化補助も追加しています。

## 主な変更

- 警告 `InteractionFlowArchitecture002` を追加
  - `IDependencyNode` 実装クラスを対象に、コンストラクタで受け取った `IDependencyNode` 系依存が `Dependency` に含まれているかを検査
  - 通常コンストラクタ / プライマリコンストラクタの両方に対応
  - `IDependencyNode` 実装クラスを継承する場合、依存引数が基底コンストラクタへ渡されているかを検査
  - `sealed` ではない `IDependencyNode` 実装クラスでは、`params IDependencyNode[] dependency` を要求
  - `Dependency` auto-property への直接代入にも対応
  - 明示的 `IDependencyNode.Dependency` 実装を正しく判定し、同名の別プロパティを誤って対象にしないよう調整

- 既存の `InteractionFlowArchitecture001` を整理
  - LayerDependencyAnalyzer 系と DependencyNodeAnalyzer 系のリソースキー・変数名を対称化
  - 診断メッセージを「共通文 + 詳細理由」の形に統一
  - 英語 / 日本語リソースに対応
  - レイヤー依存の詳細理由を `LayerDependencyDisallowedReference` として分離

- `.Standard` / `.Samples.*` の追従
  - Analyzer で必須化した `params IDependencyNode[] dependency` に合わせて各実装を修正
  - DI で `params IDependencyNode[]` を解決できるよう `ScopeServices` に空配列登録を追加

- 依存ツリー可視化を追加
  - `SystemFlowHandler<TContext>` から保持中の SystemFlow を `IDependencyNode` として取得できる `Root` を追加
  - `DependencyTreeView.GetDependencyTreeText(IDependencyNode root)` を追加
  - `IDependencyNode.Dependency` を Markdown ツリー形式で出力

- ドキュメント追加
  - `InteractionFlow.Analyzers/README.md`
  - `InteractionFlow.Analyzers.Tests/README.md`
  - Analyzer の仕様、検出対象、制限、テスト観点を整理

## テスト

Analyzer テストを拡充しました。

- レイヤー依存規則の既存検出パターン
- `IDependencyNode` 通常コンストラクタ / プライマリコンストラクタ
- `Dependency` への直接代入
- 基底 `IDependencyNode` への依存引き渡し
- `sealed` / 非 `sealed` の `params IDependencyNode[]` 要求
- en / ja リソースのメッセージ確認
- 共通文 + 詳細理由のメッセージ合成
- 明示的 interface 実装時の `Dependency` 判定

確認済み:

- `dotnet test InteractionFlow.Analyzers.Tests/InteractionFlow.Analyzers.Tests.csproj`
  - 63 passed
- `dotnet build InteractionFlow.slnx`
  - 0 warnings / 0 errors
- `dotnet test InteractionFlow.slnx`
  - 63 passed